### PR TITLE
Update INSTALL with deps

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,3 +3,22 @@ Building TheMinerzCoin
 
 See doc/build-*.md for instructions on building the various
 elements of the TheMinerzCoin reference implementation of TheMinerzCoin.
+
+Dependencies
+------------
+Before building from source make sure the basic build tools are available. On
+most Linux systems these can be installed from the package manager:
+
+```
+sudo apt-get install build-essential autoconf automake libtool pkg-config \
+    libssl-dev libevent-dev
+```
+
+Build Steps
+-----------
+Run the autotools scripts to generate the build system before invoking `make`:
+
+```
+./autogen.sh && ./configure
+make
+```


### PR DESCRIPTION
## Summary
- document common dependencies
- remind to run `./autogen.sh && ./configure` before building

## Testing
- `bash autogen.sh` *(fails: configuration failed, please install autoconf first)*
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_68661ee0d3ec832c98ee5eae410e0063