### PR TITLE
Update block time reduction height for test and regtest

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -229,7 +229,8 @@ public:
         consensus.nProtocolV2Time = 1693994591;
         consensus.nProtocolV3Time = 1693994592;
         consensus.nProtocolV3_1Time = 1667779200;
-        consensus.nBlockTimeReductionHeight = 0;
+        // match mainnet spacing reduction height
+        consensus.nBlockTimeReductionHeight = 175000;
         consensus.nRewardHalvingStart = 0;
         consensus.nRewardHalvingInterval = 100000;
         consensus.nLastPOWBlock = 0x7fffffff;
@@ -341,7 +342,8 @@ public:
         consensus.nProtocolV2Time = 1693994591;
         consensus.nProtocolV3Time = 1693994592;
         consensus.nProtocolV3_1Time = 4102437600;
-        consensus.nBlockTimeReductionHeight = 0;
+        // match mainnet spacing reduction height
+        consensus.nBlockTimeReductionHeight = 175000;
         consensus.nRewardHalvingStart = 0;
         consensus.nRewardHalvingInterval = 100000;
         consensus.nLastPOWBlock = 1000;


### PR DESCRIPTION
## Summary
- set block time reduction height on testnet/regtest to 175000
  so that spacing is only halved after the same height as mainnet

## Testing
- `sh autogen.sh` *(fails: `configuration failed, please install autoconf first`)*

