### PR TITLE
Adjust consensus functions for dynamic block rewards

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -144,7 +144,8 @@ int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& fr
         r = from.nChainWork - to.nChainWork;
         sign = -1;
     }
-    r = r * arith_uint256(params.nTargetSpacing) / GetBlockProof(tip);
+    int64_t spacing = params.GetDynamicTargetSpacing(tip.nHeight);
+    r = r * arith_uint256(spacing) / GetBlockProof(tip);
     if (r.bits() > 63) {
         return sign * std::numeric_limits<int64_t>::max();
     }

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
     for (int i = 0; i < 10000; i++) {
         blocks[i].pprev = i ? &blocks[i - 1] : NULL;
         blocks[i].nHeight = i;
-        blocks[i].nTime = 1269211443 + i * params.nTargetSpacing;
+        blocks[i].nTime = 1269211443 + i * params.GetDynamicTargetSpacing(i);
         blocks[i].nBits = 0x207fffff; /* target 0x7fffff000... */
         blocks[i].nChainWork = i ? blocks[i - 1].nChainWork + GetBlockProof(blocks[i - 1]) : arith_uint256(0);
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1949,15 +1949,20 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 {
-    int halvings = nHeight / consensusParams.nSubsidyHalvingInterval;
-    // Force block reward to zero when right shift is undefined.
-    if (halvings >= 64)
-        return 0;
+    CAmount reward = 50 * COIN;
 
-    CAmount nSubsidy = 50 * COIN;
-    // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
-    nSubsidy >>= halvings;
-    return nSubsidy;
+    if (nHeight >= consensusParams.nRewardHalvingStart &&
+        consensusParams.nRewardHalvingInterval > 0) {
+        unsigned int halvings =
+            (nHeight - consensusParams.nRewardHalvingStart) /
+                consensusParams.nRewardHalvingInterval + 1;
+        if (halvings < 64)
+            reward >>= halvings;
+        else
+            reward = 0;
+    }
+
+    return reward;
 }
 
 CoinsViews::CoinsViews(DBParams db_params, CoinsViewOptions options)


### PR DESCRIPTION
## Summary
- use dynamic block spacing when computing chain work time
- make PoW tests call dynamic spacing helper
- apply reward halving in `GetBlockSubsidy`

## Testing
- `make -C src check` *(fails: no rule to make target 'am--refresh')*

