### PR TITLE
Switch build system to CMake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
             host: x86_64-w64-mingw32
             arch: "i386"
             os: ubuntu-22.04
-            packages: nsis g++-mingw-w64-x86-64 build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git wine-binfmt wine64 wine32
+            packages: nsis g++-mingw-w64-x86-64 build-essential libtool pkg-config bsdmainutils curl git wine-binfmt wine64 wine32
             postinstall: |
               sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
               sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
@@ -111,7 +111,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch bison
+          sudo apt-get install make cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch bison
           sudo apt-get install ${{ matrix.packages }}
 
       - name: Post Install
@@ -151,9 +151,8 @@ jobs:
           make -j $MAKEJOBS -C depends HOST=${{ matrix.host }} ${{ matrix.dep-opts }}
       - name: Build theminerzcoin
         run: |
-          ./autogen.sh
-          ./configure --prefix=`pwd`/depends/${{ matrix.host }} ${{ matrix.config-opts }} --enable-reduce-exports || ( cat config.log && false)
-          make -j $MAKEJOBS ${{ matrix.goal }} || ( echo "Build failure. Verbose build follows." && make ${{ matrix.goal }} V=1 ; false )
+          ./generate_build.sh -DCMAKE_INSTALL_PREFIX=`pwd`/depends/${{ matrix.host }} ${{ matrix.config-opts }}
+          cmake --build build -j $MAKEJOBS --target ${{ matrix.goal }} || ( echo "Build failure. Verbose build follows." && cmake --build build --target ${{ matrix.goal }} -- -v ; false )
  
       - name: Check security
         if: ${{ matrix.check-security }}

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -55,7 +55,7 @@ jobs:
             host: x86_64-w64-mingw32
             arch: "i386"
             os: ubuntu-22.04
-            packages: nsis g++-mingw-w64-x86-64 build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git wine-binfmt wine64 wine32
+            packages: nsis g++-mingw-w64-x86-64 build-essential libtool pkg-config bsdmainutils curl git wine-binfmt wine64 wine32
             postinstall: |
               sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
               sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
@@ -111,7 +111,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch bison
+          sudo apt-get install make cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch bison
           sudo apt-get install ${{ matrix.packages }}
 
       - name: Post Install
@@ -151,9 +151,8 @@ jobs:
           make -j $MAKEJOBS -C depends HOST=${{ matrix.host }} ${{ matrix.dep-opts }}
       - name: Build theminerzcoin
         run: |
-          ./autogen.sh
-          ./configure --prefix=`pwd`/depends/${{ matrix.host }} ${{ matrix.config-opts }} --enable-reduce-exports || ( cat config.log && false)
-          make -j $MAKEJOBS ${{ matrix.goal }} || ( echo "Build failure. Verbose build follows." && make ${{ matrix.goal }} V=1 ; false )
+          ./generate_build.sh -DCMAKE_INSTALL_PREFIX=`pwd`/depends/${{ matrix.host }} ${{ matrix.config-opts }}
+          cmake --build build -j $MAKEJOBS --target ${{ matrix.goal }} || ( echo "Build failure. Verbose build follows." && cmake --build build --target ${{ matrix.goal }} -- -v ; false )
  
       - name: Check security
         if: ${{ matrix.check-security }}

--- a/.github/workflows/cc-cpp.yml
+++ b/.github/workflows/cc-cpp.yml
@@ -55,7 +55,7 @@ jobs:
             host: x86_64-w64-mingw32
             arch: "i386"
             os: ubuntu-22.04
-            packages: nsis g++-mingw-w64-x86-64 build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git wine-binfmt wine64 wine32
+            packages: nsis g++-mingw-w64-x86-64 build-essential libtool pkg-config bsdmainutils curl git wine-binfmt wine64 wine32
             postinstall: |
               sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
               sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
@@ -111,7 +111,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch bison
+          sudo apt-get install make cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch bison
           sudo apt-get install ${{ matrix.packages }}
 
       - name: Post Install
@@ -151,9 +151,8 @@ jobs:
           make -j $MAKEJOBS -C depends HOST=${{ matrix.host }} ${{ matrix.dep-opts }}
       - name: Build TheMinerzCoin
         run: |
-          ./autogen.sh
-          ./configure --prefix=`pwd`/depends/${{ matrix.host }} ${{ matrix.config-opts }} --enable-reduce-exports || ( cat config.log && false)
-          make -j $MAKEJOBS ${{ matrix.goal }} || ( echo "Build failure. Verbose build follows." && make ${{ matrix.goal }} V=1 ; false )
+          ./generate_build.sh -DCMAKE_INSTALL_PREFIX=`pwd`/depends/${{ matrix.host }} ${{ matrix.config-opts }}
+          cmake --build build -j $MAKEJOBS --target ${{ matrix.goal }} || ( echo "Build failure. Verbose build follows." && cmake --build build --target ${{ matrix.goal }} -- -v ; false )
  
       - name: Check security
         if: ${{ matrix.check-security }}

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ src/qt/theminerzcoin-qt.creator
 src/qt/theminerzcoin-qt.creator.user
 src/qt/theminerzcoin-qt.files
 src/qt/theminerzcoin-qt.includes
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.16)
+project(TheMinerzCoin VERSION 3.0.0 LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_subdirectory(src/leveldb)
+add_subdirectory(src/crc32c)
+
+# install documentation
+install(DIRECTORY doc DESTINATION share/theminerzcoin)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,15 +10,14 @@ Before building from source make sure the basic build tools are available. On
 most Linux systems these can be installed from the package manager:
 
 ```
-sudo apt-get install build-essential autoconf automake libtool pkg-config \
-    libssl-dev libevent-dev
+sudo apt-get install build-essential cmake libssl-dev libevent-dev pkg-config
 ```
 
 Build Steps
 -----------
-Run the autotools scripts to generate the build system before invoking `make`:
+Generate the build system using CMake and then build:
 
 ```
-./autogen.sh && ./configure
-make
+./generate_build.sh
+./build.sh
 ```

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ lots of money.
 ### Automated Testing
 
 Developers are strongly encouraged to write [unit tests](/doc/unit-tests.md) for new code, and to
-submit new unit tests for old code. Unit tests can be compiled and run
-(assuming they weren't disabled in configure) with: `make check`
+submit new unit tests for old code. Unit tests can be built after running `./generate_build.sh`
+and executed with: `cmake --build build --target check`
 
 There are also [regression and integration tests](/qa) of the RPC interface, written
 in Python, that are run automatically on the build server.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+cmake --build build "$@"

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -36,19 +36,18 @@ Build TheMinerzCoin
 
     Configure and build the headless theminerzcoin binaries as well as the GUI (if Qt is found).
 
-    You can disable the GUI build by passing `--without-gui` to configure.
+    You can disable the GUI build by passing `-DWITH_GUI=OFF` to CMake.
 
-        ./autogen.sh
-        ./configure
-        make
+        ./generate_build.sh
+        ./build.sh
 
 3.  It is recommended to build and run the unit tests:
 
-        make check
+        cmake --build build --target check
 
 4.  You can also create a .dmg that contains the .app bundle (optional):
 
-        make deploy
+        cmake --build build --target deploy
 
 Running
 -------
@@ -81,7 +80,7 @@ Download and install the community edition of [Qt Creator](https://www.qt.io/dow
 Uncheck everything except Qt Creator during the installation process.
 
 1. Make sure you installed everything through Homebrew mentioned above
-2. Do a proper ./configure --enable-debug
+2. Generate build files with `./generate_build.sh -DCMAKE_BUILD_TYPE=Debug`
 3. In Qt Creator do "New Project" -> Import Project -> Import Existing Project
 4. Enter "theminerzcoin-qt" as project name, enter src/qt as location
 5. Leave the file selection as it is

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -18,10 +18,9 @@ To Build
 ---------------------
 
 ```bash
-./autogen.sh
-./configure
-make
-make install # optional
+./generate_build.sh
+./build.sh
+./install.sh # optional
 ```
 
 This will build theminerzcoin-qt as well if the dependencies are met.
@@ -180,8 +179,7 @@ make install
 
 # Configure TheMinerzCoin to use our own-built instance of BDB
 cd $BITCOIN_ROOT
-./autogen.sh
-./configure LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/" # (other args...)
+./generate_build.sh -DCMAKE_INSTALL_PREFIX=$BDB_PREFIX -DCMAKE_C_FLAGS="-I${BDB_PREFIX}/include" -DCMAKE_EXE_LINKER_FLAGS="-L${BDB_PREFIX}/lib" # (other args...)
 ```
 
 **Note**: You only need Berkeley DB if the wallet is enabled (see the section *Disable-Wallet mode* below).
@@ -270,9 +268,8 @@ This example lists the steps necessary to setup and build a command line only, n
     pacman -S git base-devel boost libevent python
     git clone https://github.com/MrMiner-org/TheMinerzCoin.git
     cd theminerzcoin/
-    ./autogen.sh
-    ./configure --disable-wallet --without-gui --without-miniupnpc
-    make check
+    ./generate_build.sh -DWITH_WALLET=OFF -DWITH_GUI=OFF -DWITH_MINIUPNPC=OFF
+    cmake --build build --target check
 
 Note:
 Enabling wallet support requires either compiling against a Berkeley DB newer than 6.2 (package `db`) using `--with-incompatible-bdb`,
@@ -327,9 +324,8 @@ with 4.8-built Bitcoin Core is needed follow the steps under "Berkeley DB" above
 
 Then build using:
 
-    ./autogen.sh
-    ./configure --with-incompatible-bdb BDB_CFLAGS="-I/usr/local/include/db5" BDB_LIBS="-L/usr/local/lib -ldb_cxx-5"
-    make
+    ./generate_build.sh -DWITH_INCOMPATIBLE_BDB=ON -DBDB_CFLAGS="-I/usr/local/include/db5" -DBDB_LIBS="-L/usr/local/lib -ldb_cxx-5"
+    ./build.sh
 
 *Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
 It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -103,9 +103,8 @@ Build using:
     cd depends
     make HOST=x86_64-w64-mingw32
     cd ..
-    ./autogen.sh
-    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
-    make
+    ./generate_build.sh -DCMAKE_TOOLCHAIN_FILE=$PWD/depends/x86_64-w64-mingw32/share/toolchain.cmake -DCMAKE_INSTALL_PREFIX=/
+    ./build.sh
     sudo bash -c "echo 1 > /proc/sys/fs/binfmt_misc/status" # Enable WSL support for Win32 applications.
 
 ## Depends system

--- a/doc/productivity.md
+++ b/doc/productivity.md
@@ -45,16 +45,16 @@ Note: base_dir is required for ccache to share cached compiles of the same file 
 
 You _must not_ set base_dir to "/", or anywhere that contains system headers (according to the ccache docs).
 
-### Disable features with `./configure`
+### Configure features with CMake
 
-After running `./autogen.sh`, which generates the `./configure` file, use `./configure --help` to identify features that you can disable to save on compilation time. A few common flags:
+After generating build files using `./generate_build.sh`, you can pass options to CMake to disable components:
 
 ```sh
---without-miniupnpc
---without-natpmp
---disable-bench
---disable-wallet
---without-gui
+-DWITH_MINIUPNPC=OFF
+-DWITH_NATPMP=OFF
+-DBUILD_BENCH=OFF
+-DWITH_WALLET=OFF
+-DWITH_GUI=OFF
 ```
 
 If you do need the wallet enabled, it is common for devs to add `--with-incompatible-bdb`. This uses your system bdb version for the wallet, so you don't have to find a copy of bdb 4.8. Wallets from such a build will be incompatible with any release binary (and vice versa), so use with caution on mainnet.

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -47,10 +47,10 @@ operation.
 ## Enabling
 
 By default, the ZeroMQ feature is automatically compiled in if the
-necessary prerequisites are found.  To disable, use --disable-zmq
-during the *configure* step of building bitcoind:
+necessary prerequisites are found. To disable, pass `-DWITH_ZMQ=OFF`
+when running CMake:
 
-    $ ./configure --disable-zmq (other options)
+    $ ./generate_build.sh -DWITH_ZMQ=OFF (other options)
 
 To actually enable operation, one must set the appropriate options on
 the command line or in the configuration file.

--- a/generate_build.sh
+++ b/generate_build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+cmake -S . -B build "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+cmake --install build "$@"


### PR DESCRIPTION
## Summary
- add top level `CMakeLists.txt`
- provide `generate_build.sh`, `build.sh`, and `install.sh` helpers
- ignore `build/` directory
- document CMake usage in INSTALL and other docs
- update GitHub Actions to run CMake instead of Autotools

## Testing
- `./generate_build.sh` *(fails: set_property could not find TARGET glog)*

