### PR TITLE
Fix stale links and domains

### DIFF
--- a/contrib/blk
+++ b/contrib/blk
@@ -26,8 +26,8 @@ stake )
 ;;
 
 latest )
-	latest=$($blkc  getblockcount) && \
-	    blacksight=$(curl -s https://node.theminerzcoin.io/insight-api/block-index/$latest? |  cut -d '"' -f4) && \
+        latest=$($blkc  getblockcount) && \
+            blacksight=$(curl -s https://node.theminerzcoin.eu/insight-api/block-index/$latest? |  cut -d '"' -f4) && \
 	    theminerzcoin=$($blkc  getblockhash $latest) && \
 	    diff -sy --label Local <(echo $theminerzcoin) --label Explorer <(echo $blacksight)
 ;;

--- a/contrib/init/theminerzcoind.conf
+++ b/contrib/init/theminerzcoind.conf
@@ -39,7 +39,7 @@ pre-start script
         echo "notified of problems:"
         echo
         echo "ie: alertnotify=echo %%s | mail -s \"TheMinerzCoin Alert\"" \
-            "team@theminerzcoin.org"
+            "team@theminerzcoin.eu"
         echo
         exit 1
     fi

--- a/contrib/init/theminerzcoind.openrc
+++ b/contrib/init/theminerzcoind.openrc
@@ -86,7 +86,7 @@ checkconfig()
 		eerror "notified of problems:"
 		eerror ""
 		eerror "ie: alertnotify=echo %%s | mail -s \"TheMinerzCoin Alert\"" \
-			"team@theminerzcoin.org"
+                        "team@theminerzcoin.eu"
 		eerror ""
 		return 1
 	fi

--- a/doc/README.md
+++ b/doc/README.md
@@ -5,7 +5,7 @@ Setup
 ---------------------
 TheMinerzCoin is a TheMinerzCoin client and it builds the backbone of the network. However, it downloads and stores the entire history of TheMinerzCoin transactions (which is currently several GBs); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
 
-To download TheMinerzCoin, visit [theminerzcoinmore.org](https://theminerzcoin.eu/).
+To download TheMinerzCoin, visit [theminerzcoin.eu](https://theminerzcoin.eu/).
 
 Running
 ---------------------

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -31,7 +31,7 @@
  *
  * \section intro_sec Introduction
  *
- * This is the developer documentation of the reference client for an experimental new digital currency called TheMinerzCoin (https://theminerzcoin.org/),
+ * This is the developer documentation of the reference client for an experimental new digital currency called TheMinerzCoin (https://theminerzcoin.eu/),
  * which enables instant payments to anyone, anywhere in the world. Bitcoin uses peer-to-peer technology to operate
  * with no central authority: managing transactions and issuing money are carried out collectively by the network.
  *

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -49,7 +49,7 @@ static const int MAX_URI_LENGTH = 255;
 #define SPINNER_FRAMES 36
 
 #define QAPP_ORG_NAME "TheMinerzCoin"
-#define QAPP_ORG_DOMAIN "theminerzcoinmore.org"
+#define QAPP_ORG_DOMAIN "theminerzcoin.eu"
 #define QAPP_APP_NAME_DEFAULT "TheMinerzCoin-Qt"
 #define QAPP_APP_NAME_TESTNET "TheMinerzCoin-Qt-testnet"
 


### PR DESCRIPTION
## Summary
- update doc download link to new domain
- use updated project domain in Qt GUI constants
- fix outdated links in initialization files and example scripts

## Testing
- `./generate_build.sh` *(fails: FindQt5.cmake not found)*
