### PR TITLE
Add RPC/GraphQL specs references

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ Changes should be tested by somebody other than the developer who wrote the
 code. This is especially important for large or high-risk changes. It is useful
 to add a test plan to the pull request description if testing the changes is
 not straightforward.
+
+### API specifications
+
+The RPC/REST API is documented in [specs/openapi.yaml](specs/openapi.yaml).
+A prototype GraphQL schema lives in [specs/schema.graphql](specs/schema.graphql).

--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -5,6 +5,9 @@ The headless daemon `theminerzcoind` has the JSON-RPC API enabled by default, th
 option. In the GUI it is possible to execute RPC methods in the Debug Console
 Dialog.
 
+An experimental OpenAPI specification covering these RPC calls is
+available at [../specs/openapi.yaml](../specs/openapi.yaml).
+
 ## Versioning
 
 The RPC interface might change from one major version of TheMinerzCoin to the

--- a/doc/README.md
+++ b/doc/README.md
@@ -58,6 +58,8 @@ The TheMinerzCoin repo's [root README](/README.md) contains relevant information
 - [Translation Strings Policy](translation_strings_policy.md)
 - [Unit Tests](unit-tests.md)
 - [Unauthenticated REST Interface](REST-interface.md)
+- [RPC/REST OpenAPI Specification](../specs/openapi.yaml)
+- [GraphQL Schema](../specs/schema.graphql)
 - [Shared Libraries](shared-libraries.md)
 - [BIPS](bips.md)
 - [Dnsseed Policy](dnsseed-policy.md)

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -6,6 +6,9 @@ The REST API can be enabled with the `-rest` option.
 The interface runs on the same port as the JSON-RPC interface, by default port 13947 for mainnet, port 23947 for testnet,
 and port 35715 for regtest.
 
+An OpenAPI description of the available endpoints is maintained in
+[../specs/openapi.yaml](../specs/openapi.yaml).
+
 REST Interface consistency guarantees
 -------------------------------------
 

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -9,3 +9,32 @@ paths:
       responses:
         '200':
           description: blockchain info
+  /getblock/{hash}:
+    get:
+      summary: Get block details
+      parameters:
+        - name: hash
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: block data
+  /sendtoaddress:
+    post:
+      summary: Send coins to address
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                address:
+                  type: string
+                amount:
+                  type: number
+      responses:
+        '200':
+          description: transaction id

--- a/specs/schema.graphql
+++ b/specs/schema.graphql
@@ -1,12 +1,28 @@
 schema {
   query: Query
+  mutation: Mutation
 }
 
 type Query {
   block(height: Int!): Block
+  transaction(txid: String!): Transaction
+  mempool: [Transaction!]!
+}
+
+type Mutation {
+  sendRawTransaction(hex: String!): SendResult
 }
 
 type Block {
   hash: String!
   height: Int!
+}
+
+type Transaction {
+  txid: String!
+  hex: String
+}
+
+type SendResult {
+  txid: String!
 }


### PR DESCRIPTION
## Summary
- extend OpenAPI RPC definitions
- add planned GraphQL operations
- reference specs from docs

## Testing
- `python3 qa/pull-tester/rpc-tests.py --help` *(fails: ModuleNotFoundError: No module named 'tests_config')*
