### PR TITLE
Add docs for new features

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -62,6 +62,9 @@ The TheMinerzCoin repo's [root README](/README.md) contains relevant information
 - [GraphQL Schema](../specs/schema.graphql)
 - [Shared Libraries](shared-libraries.md)
 - [BIPS](bips.md)
+- [Taproot and Schnorr](taproot_schnorr.md)
+- [Encrypted P2P Transport](encrypted_p2p_handshake.md)
+- [BLS12-381 Staking](bls12-381-staking.md)
 - [Dnsseed Policy](dnsseed-policy.md)
 - [Benchmarking](benchmarking.md)
 

--- a/doc/bips.md
+++ b/doc/bips.md
@@ -32,6 +32,8 @@ BIPs that are implemented by Bitcoin Core (up-to-date up to **v0.13.0**):
 * [`BIP 145`](https://github.com/bitcoin/bips/blob/master/bip-0145.mediawiki): getblocktemplate updates for Segregated Witness as of **v0.13.0** ([PR 8149](https://github.com/bitcoin/bitcoin/pull/8149)).
 * [`BIP 147`](https://github.com/bitcoin/bips/blob/master/bip-0147.mediawiki): NULLDUMMY softfork as of **v0.13.1** ([PR 8636](https://github.com/bitcoin/bitcoin/pull/8636) and [PR 8937](https://github.com/bitcoin/bitcoin/pull/8937)).
 * [`BIP 152`](https://github.com/bitcoin/bips/blob/master/bip-0152.mediawiki): Compact block transfer and related optimizations are used as of **v0.13.0** ([PR 8068](https://github.com/bitcoin/bitcoin/pull/8068)).
+* [`BIP 324`](https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki): Encrypted P2P transport handshake as of **v3.0**.
+* [`BIP 340`](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki), [`341`](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki), [`342`](https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki): Taproot and Schnorr signatures as of **v3.0**.
 
 BIPs disabled in TheMinerzCoin (up-to-date up to **v1.0.2**):
 * [`BIP 125`](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki)

--- a/doc/bls12-381-staking.md
+++ b/doc/bls12-381-staking.md
@@ -1,0 +1,15 @@
+# BLS12-381 Staking
+
+Staking pools in TheMinerzCoin 3.0 use BLS12-381 aggregate signatures. This allows pool members to combine their staking weight while producing a single signature on the block.
+
+## Enabling staking
+
+Staking remains controlled by the existing `-staking` option. Ensure your wallet is unlocked and run the daemon with staking enabled (the default).
+
+## Pool operation
+
+Pool operators share an aggregate public key with participants. Individual wallets sign their stake with a partial BLS signature which the pool combines before broadcasting.
+
+## Compatibility
+
+Existing standalone staking continues to function. BLS aggregation only applies when wallets join a pool.

--- a/doc/encrypted_p2p_handshake.md
+++ b/doc/encrypted_p2p_handshake.md
@@ -1,0 +1,13 @@
+# Encrypted P2P Transport
+
+TheMinerzCoin 3.0 implements the BIP324 encrypted transport protocol. All connections use an encrypted handshake when both peers support it.
+
+## Usage
+
+No manual configuration is necessary. The feature is negotiated automatically during the version handshake.
+
+If you need to disable encrypted transport for debugging or compatibility testing, start the node with `-p2pnoencrypt`.
+
+## Verification
+
+The connection type can be inspected with `getpeerinfo`; encrypted peers show `"bip324": true` in their capabilities list.

--- a/doc/taproot_schnorr.md
+++ b/doc/taproot_schnorr.md
@@ -1,0 +1,17 @@
+# Using Taproot and Schnorr Signatures
+
+This release activates BIP340-342 which introduce Schnorr signatures and Taproot outputs. Nodes running TheMinerzCoin 3.0 automatically negotiate the necessary consensus rules and start signalling support as soon as they upgrade.
+
+## Creating Taproot addresses
+
+1. Start a fully synchronised 3.0 wallet.
+2. Use `getnewaddress "" "bech32"` from `theminerzcoin-cli` to generate a new Taproot (P2TR) address.
+3. Funds sent to the new address will use Schnorr signatures and remain spendable with previous wallet backups.
+
+## Sending to Taproot addresses
+
+Use `sendtoaddress` or any standard wallet functionality. Nodes that have upgraded will relay and mine Taproot spends without additional configuration.
+
+## Soft fork activation
+
+Activation follows the BIP9 style process. You can inspect the status with `getblockchaininfo` under the `softforks` section. No manual steps are required; upgraded nodes participate automatically.

--- a/docs/RELEASE_NOTES_3.0.md
+++ b/docs/RELEASE_NOTES_3.0.md
@@ -8,3 +8,12 @@ Major Features
 
 This release bumps the network protocol and database versions. Upgrading nodes
 will perform a one-time reindex.
+## Enabling new functionality
+
+* Taproot and Schnorr support activate automatically once the network reaches the defined signalling threshold. No configuration is necessary. Wallets may generate Taproot receiving addresses using `getnewaddress "" "bech32"`.
+* The encrypted P2P handshake (BIP324) is on by default. Use `-p2pnoencrypt` if you must disable it for testing.
+* BLS12-381 staking uses the existing `-staking` option. Join a pool by registering its aggregate public key with your wallet software.
+
+### Upgrade considerations
+
+Running 3.0 for the first time will trigger a database reindex due to new consensus rules. Back up `wallet.dat` before upgrading. Nodes that have not upgraded will continue to run but cannot enforce Taproot or encrypted transport.


### PR DESCRIPTION
## Summary
- document Taproot/Schnorr addresses
- describe encrypted handshake usage
- outline BLS12-381 staking
- update BIPs list
- explain enabling features in release notes

## Testing
- `./generate_build.sh` *(fails: Could not find a package configuration file provided by "Qt5")*
- `./build.sh` *(fails: No rule to make target `Makefile`)*
