### PR TITLE
Update API specs with wallet, staking, network endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,7 @@ not straightforward.
 
 ### API specifications
 
-The RPC/REST API is documented in [specs/openapi.yaml](specs/openapi.yaml).
-A prototype GraphQL schema lives in [specs/schema.graphql](specs/schema.graphql).
+The RPC/REST API—covering wallet management, staking operations and network
+statistics—is documented in [specs/openapi.yaml](specs/openapi.yaml). A prototype
+GraphQL schema describing the same functionality lives in
+[specs/schema.graphql](specs/schema.graphql).

--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -5,8 +5,10 @@ The headless daemon `theminerzcoind` has the JSON-RPC API enabled by default, th
 option. In the GUI it is possible to execute RPC methods in the Debug Console
 Dialog.
 
-An experimental OpenAPI specification covering these RPC calls is
-available at [../specs/openapi.yaml](../specs/openapi.yaml).
+An experimental OpenAPI specification covering these RPC calls, including wallet
+management and staking endpoints, is available at
+[../specs/openapi.yaml](../specs/openapi.yaml). A prototype GraphQL schema is
+maintained alongside it at [../specs/schema.graphql](../specs/schema.graphql).
 
 ## Versioning
 

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -6,8 +6,10 @@ The REST API can be enabled with the `-rest` option.
 The interface runs on the same port as the JSON-RPC interface, by default port 13947 for mainnet, port 23947 for testnet,
 and port 35715 for regtest.
 
-An OpenAPI description of the available endpoints is maintained in
-[../specs/openapi.yaml](../specs/openapi.yaml).
+An OpenAPI description of the available endpoints, including wallet and staking
+operations, is maintained in [../specs/openapi.yaml](../specs/openapi.yaml).
+The evolving GraphQL schema can be found at
+[../specs/schema.graphql](../specs/schema.graphql).
 
 REST Interface consistency guarantees
 -------------------------------------

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -38,3 +38,59 @@ paths:
       responses:
         '200':
           description: transaction id
+  /wallet/create:
+    post:
+      summary: Create a new wallet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: wallet created
+  /wallet/{name}/balance:
+    get:
+      summary: Get wallet balance
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: wallet balance
+  /staking/delegate:
+    post:
+      summary: Delegate stake
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                address:
+                  type: string
+                amount:
+                  type: number
+      responses:
+        '200':
+          description: delegation tx id
+  /staking/status:
+    get:
+      summary: Get staking status
+      responses:
+        '200':
+          description: staking status
+  /network/stats:
+    get:
+      summary: Get network statistics
+      responses:
+        '200':
+          description: network statistics

--- a/specs/schema.graphql
+++ b/specs/schema.graphql
@@ -7,10 +7,14 @@ type Query {
   block(height: Int!): Block
   transaction(txid: String!): Transaction
   mempool: [Transaction!]!
+  wallet(name: String!): Wallet
+  networkStats: NetworkStats!
 }
 
 type Mutation {
   sendRawTransaction(hex: String!): SendResult
+  createWallet(name: String!): Wallet
+  delegateStake(address: String!, amount: Float!): SendResult
 }
 
 type Block {
@@ -25,4 +29,15 @@ type Transaction {
 
 type SendResult {
   txid: String!
+}
+
+type Wallet {
+  name: String!
+  balance: Float!
+}
+
+type NetworkStats {
+  blocks: Int!
+  difficulty: Float!
+  stakeWeight: Float!
 }


### PR DESCRIPTION
## Summary
- expand OpenAPI definitions with wallet, staking and network stats endpoints
- extend GraphQL schema with wallet and network types and new mutations
- link the specs from README and documentation pages

## Testing
- `cmake --build build --target check` *(fails: `/workspace/TheMinerzCoin/build is not a directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68664a2711c0832c91187feff58b6fee