### PR TITLE
Persist BLS pool public key

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2917,8 +2917,6 @@ UniValue burnwallet(const UniValue& params, bool fHelp)
 }
 */
 
-static std::array<unsigned char, 96> g_poolPubKey{};
-static bool g_poolRegistered = false;
 
 static UniValue registerpool(const UniValue& params, bool fHelp)
 {
@@ -2928,11 +2926,13 @@ static UniValue registerpool(const UniValue& params, bool fHelp)
             "Register aggregated pool BLS public key");
 
     std::vector<unsigned char> data = ParseHexV(params[0], "pubkey");
-    if (data.size() != g_poolPubKey.size())
+    if (data.size() != g_blsPoolPubKey.size())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid public key length");
 
-    std::copy(data.begin(), data.end(), g_poolPubKey.begin());
+    std::copy(data.begin(), data.end(), g_blsPoolPubKey.begin());
     g_poolRegistered = true;
+    if (pwalletMain)
+        CWalletDB(pwalletMain->strWalletFile).WritePoolPubKey(g_blsPoolPubKey);
 
     UniValue res(UniValue::VOBJ);
     res.pushKV("registered", true);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -44,6 +44,8 @@ CWallet* pwalletMain = NULL;
 CFeeRate payTxFee(DEFAULT_TRANSACTION_FEE);
 unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;
 bool bSpendZeroConfChange = DEFAULT_SPEND_ZEROCONF_CHANGE;
+std::array<unsigned char,96> g_blsPoolPubKey{};
+bool g_poolRegistered = false;
 
 const char * DEFAULT_WALLET_DAT = "wallet.dat";
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -18,6 +18,7 @@
 #include "wallet/rpcwallet.h"
 #include "pos.h"
 
+#include <array>
 #include <algorithm>
 #include <atomic>
 #include <map>
@@ -40,6 +41,8 @@ extern unsigned int nDonationPercentage;
 extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
 extern bool fWalletUnlockStakingOnly;
+extern std::array<unsigned char,96> g_blsPoolPubKey;
+extern bool g_poolRegistered;
 
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 100;
 //! -paytxfee default

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -8,6 +8,7 @@
 #include "wallet/walletdb.h"
 
 #include "base58.h"
+#include <array>
 #include "consensus/validation.h"
 #include "main.h" // For CheckTransaction
 #include "dstencode.h"
@@ -624,6 +625,11 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 return false;
             }
         }
+        else if (strType == "poolpubkey")
+        {
+            ssValue >> g_blsPoolPubKey;
+            g_poolRegistered = true;
+        }
     } catch (...)
     {
         return false;
@@ -1040,4 +1046,15 @@ bool CWalletDB::WriteHDChain(const CHDChain& chain)
 {
     nWalletDBUpdated++;
     return Write(std::string("hdchain"), chain);
+}
+
+bool CWalletDB::WritePoolPubKey(const std::array<unsigned char,96>& key)
+{
+    nWalletDBUpdated++;
+    return Write(std::string("poolpubkey"), key);
+}
+
+bool CWalletDB::ReadPoolPubKey(std::array<unsigned char,96>& key)
+{
+    return Read(std::string("poolpubkey"), key);
 }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -182,6 +182,9 @@ public:
     //! write the hdchain model (external chain child index counter)
     bool WriteHDChain(const CHDChain& chain);
 
+    bool WritePoolPubKey(const std::array<unsigned char,96>& key);
+    bool ReadPoolPubKey(std::array<unsigned char,96>& key);
+
 private:
     CWalletDB(const CWalletDB&);
     void operator=(const CWalletDB&);


### PR DESCRIPTION
## Summary
- persist BLS staking pool pubkey in the wallet DB
- write the pool key on `registerpool` RPC
- load the key when the wallet initializes

## Testing
- `./generate_build.sh` *(fails: add_subdirectory given source "third_party/glog" which is not an existing directory)*

