### PR TITLE
Add -dandelion argument

### DIFF
--- a/docs/RELEASE_NOTES_3.0.md
+++ b/docs/RELEASE_NOTES_3.0.md
@@ -14,6 +14,7 @@ will perform a one-time reindex.
 * Taproot and Schnorr support activate automatically once the network reaches the defined signalling threshold. No configuration is necessary. Wallets may generate Taproot receiving addresses using `getnewaddress "" "bech32"`.
 * The encrypted P2P handshake (BIP324) is on by default. Use `-p2pnoencrypt` if you must disable it for testing.
 * BLS12-381 staking uses the existing `-staking` option. Join a pool by registering its aggregate public key with your wallet software.
+* Dandelion++ transaction relay is enabled by default. Use `-dandelion=0` to disable it if desired.
 
 ### Upgrade considerations
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -367,6 +367,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), DEFAULT_PERMIT_BAREMULTISIG));
     strUsage += HelpMessageOpt("-peerbloomfilters", strprintf(_("Support filtering of blocks and transaction with bloom filters (default: %u)"), DEFAULT_PEERBLOOMFILTERS));
+    strUsage += HelpMessageOpt("-dandelion", strprintf(_("Enable Dandelion++ transaction relay (default: %u)"), DEFAULT_DANDELION));
     strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u or testnet: %u)"), Params(CBaseChainParams::MAIN).GetDefaultPort(), Params(CBaseChainParams::TESTNET).GetDefaultPort()));
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));
     strUsage += HelpMessageOpt("-proxyrandomize", strprintf(_("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)"), DEFAULT_PROXYRANDOMIZE));
@@ -1206,6 +1207,7 @@ bool AppInit2(Config& config, boost::thread_group& threadGroup, CScheduler& sche
     fDiscover = GetBoolArg("-discover", true);
     fNameLookup = GetBoolArg("-dns", DEFAULT_NAME_LOOKUP);
     fRelayTxes = !GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY);
+    fDandelion = GetBoolArg("-dandelion", DEFAULT_DANDELION);
 
     bool fBound = false;
     if (fListen) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -88,7 +88,7 @@ bool fListen = true;
 ServiceFlags nLocalServices = NODE_NETWORK;
 bool fRelayTxes = true;
 // Enable experimental Dandelion++ transaction relay
-bool fDandelion = true;
+bool fDandelion = DEFAULT_DANDELION;
 CCriticalSection cs_mapLocalHost;
 std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfLimited[NET_MAX] = {};

--- a/src/net.h
+++ b/src/net.h
@@ -71,6 +71,9 @@ static const uint64_t DEFAULT_MAX_UPLOAD_TARGET = 0;
 /** Default for blocks only*/
 static const bool DEFAULT_BLOCKSONLY = false;
 
+/** Default for Dandelion++ transaction relay */
+static const bool DEFAULT_DANDELION = true;
+
 static const bool DEFAULT_FORCEDNSSEED = false;
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;


### PR DESCRIPTION
## Summary
- add `DEFAULT_DANDELION` constant
- parse `-dandelion` argument and hook to `fDandelion`
- document the flag in help messages and release notes

## Testing
- `cmake -S . -B build` *(fails: could not find Qt5)*
- `cmake -S . -B build -DBUILD_BITCOIN_QT=OFF` *(fails: could not find Qt5)*

