### PR TITLE
Fix infinite flush loop

### DIFF
--- a/src/p2p/dandelion.cpp
+++ b/src/p2p/dandelion.cpp
@@ -14,11 +14,20 @@ void AddToStemPool(const CTransaction& tx)
     g_stem_pool.push_back(tx);
 }
 
+static void BroadcastTransactionDirect(const CTransaction& tx)
+{
+    CInv inv(MSG_TX, tx.GetHash());
+    LOCK(cs_vNodes);
+    for (CNode* pnode : vNodes) {
+        pnode->PushInventory(inv);
+    }
+}
+
 void FlushStemPool()
 {
     LOCK(cs_stem);
     while (!g_stem_pool.empty()) {
-        RelayTransaction(g_stem_pool.front());
+        BroadcastTransactionDirect(g_stem_pool.front());
         g_stem_pool.pop_front();
     }
 }

--- a/src/test/dandelion_tests.cpp
+++ b/src/test/dandelion_tests.cpp
@@ -2,6 +2,7 @@
 #include "test/test_bitcoin.h"
 #include <p2p/dandelion.h>
 #include <primitives/transaction.h>
+#include <boost/thread.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(dandelion_tests, BasicTestingSetup)
 
@@ -12,8 +13,9 @@ BOOST_AUTO_TEST_CASE(queue_and_flush)
     mut.vout.resize(1);
     CTransaction tx(mut);
     p2p::AddToStemPool(tx);
-    p2p::FlushStemPool();
-    BOOST_CHECK(true); // no crash
+    boost::thread t(p2p::FlushStemPool);
+    bool joined = t.timed_join(boost::posix_time::seconds(1));
+    BOOST_CHECK(joined);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- avoid re-queueing transactions when flushing Dandelion stem pool
- test that the flush call finishes

## Testing
- `./generate_build.sh` *(fails: third_party/* missing)*
