### PR TITLE
Enable sanitizer builds and add fuzz target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        sanitizer: [none]
+        include:
+          - os: ubuntu-latest
+            sanitizer: address
+          - os: ubuntu-latest
+            sanitizer: undefined
     runs-on: ${{ matrix.os }}
     steps:
+    - if: matrix.sanitizer != 'none'
+      name: Set sanitizer flags
+      run: |
+        echo "CFLAGS=-fsanitize=${{ matrix.sanitizer }}" >> $GITHUB_ENV
+        echo "CXXFLAGS=-fsanitize=${{ matrix.sanitizer }}" >> $GITHUB_ENV
+        echo "LDFLAGS=-fsanitize=${{ matrix.sanitizer }}" >> $GITHUB_ENV
     - uses: actions/checkout@v3
     - name: Configure
       run: cmake -S . -B build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,3 +22,4 @@ add_subdirectory(p2p)
 add_subdirectory(univalue)
 add_subdirectory(secp256k1)
 
+add_subdirectory(test)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(fuzz)

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(tx_deser_fuzz transaction_deserialize.cpp)
+target_include_directories(tx_deser_fuzz PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../)

--- a/src/test/fuzz/transaction_deserialize.cpp
+++ b/src/test/fuzz/transaction_deserialize.cpp
@@ -1,0 +1,15 @@
+#include "primitives/transaction.h"
+#include "streams.h"
+#include "version.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    try {
+        CDataStream stream((const char*)data, (const char*)data + size, SER_NETWORK, PROTOCOL_VERSION);
+        CTransaction tx;
+        stream >> tx;
+    } catch (const std::exception&) {
+        // ignore deserialization errors
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- build CI jobs with AddressSanitizer and UndefinedBehaviorSanitizer
- add fuzz target for transaction deserialization
- build fuzz targets via new `src/test` CMake subdirectory

## Testing
- `cmake -S . -B build` *(fails: could not find Qt5 package)*
- `cmake --build build -j2` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68667365d95c832c97588326deac391c