### PR TITLE
Implement Dandelion++ stem/fluff relay

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2005,6 +2005,7 @@ void ThreadMessageHandler()
         }
 
         if (fDandelion) {
+            // Periodically flush expired Dandelion stem transactions
             p2p::FlushStemPool();
         }
 
@@ -2305,6 +2306,7 @@ instance_of_cnetcleanup;
 void RelayTransaction(const CTransaction& tx)
 {
     if (fDandelion) {
+        // Relay via Dandelion++ stem phase first
         p2p::AddToStemPool(tx);
         return;
     }

--- a/src/p2p/dandelion.cpp
+++ b/src/p2p/dandelion.cpp
@@ -2,16 +2,39 @@
 #include <net.h>
 #include <sync.h>
 #include <deque>
+#include <map>
+#include <vector>
+#include "random.h"
+#include "utiltime.h"
 
 namespace p2p {
 
-static CCriticalSection cs_stem;
-static std::deque<CTransaction> g_stem_pool;
+/** Time in seconds a transaction stays embargoed in the stem phase. */
+static const int64_t EMBARGO_MIN = 10;
+static const int64_t EMBARGO_MAX = 30;
 
-void AddToStemPool(const CTransaction& tx)
+struct PendingTx {
+    CTransaction tx;
+    int64_t embargo_expiry;
+};
+
+static CCriticalSection cs_stem;
+static std::map<uint256, PendingTx> g_stem_pool;
+
+/** Select a random outbound peer for stem relay. */
+static CNode* SelectStemPeer()
 {
-    LOCK(cs_stem);
-    g_stem_pool.push_back(tx);
+    LOCK(cs_vNodes);
+    std::vector<CNode*> candidates;
+    for (CNode* pnode : vNodes) {
+        if (!pnode->fInbound && !pnode->fDisconnect && pnode->fRelayTxes) {
+            candidates.push_back(pnode);
+        }
+    }
+    if (candidates.empty()) {
+        return nullptr;
+    }
+    return candidates[GetRandInt(candidates.size())];
 }
 
 static void BroadcastTransactionDirect(const CTransaction& tx)
@@ -23,12 +46,42 @@ static void BroadcastTransactionDirect(const CTransaction& tx)
     }
 }
 
+void AddToStemPool(const CTransaction& tx)
+{
+    CNode* stem_peer = SelectStemPeer();
+    if (!stem_peer) {
+        // No suitable outbound peer, fluff immediately
+        BroadcastTransactionDirect(tx);
+        return;
+    }
+
+    CInv inv(MSG_TX, tx.GetHash());
+    stem_peer->PushInventory(inv);
+
+    PendingTx entry{tx, GetTime() + EMBARGO_MIN + GetRandInt(EMBARGO_MAX - EMBARGO_MIN)};
+
+    LOCK(cs_stem);
+    g_stem_pool[tx.GetHash()] = entry;
+}
+
 void FlushStemPool()
 {
-    LOCK(cs_stem);
-    while (!g_stem_pool.empty()) {
-        BroadcastTransactionDirect(g_stem_pool.front());
-        g_stem_pool.pop_front();
+    std::vector<CTransaction> expired;
+    {
+        LOCK(cs_stem);
+        int64_t now = GetTime();
+        for (auto it = g_stem_pool.begin(); it != g_stem_pool.end();) {
+            if (now >= it->second.embargo_expiry) {
+                expired.push_back(it->second.tx);
+                it = g_stem_pool.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    for (const CTransaction& tx : expired) {
+        BroadcastTransactionDirect(tx);
     }
 }
 

--- a/src/p2p/dandelion.h
+++ b/src/p2p/dandelion.h
@@ -6,7 +6,7 @@ namespace p2p {
 /** Queue a transaction for Dandelion++ stem relay. */
 void AddToStemPool(const CTransaction& tx);
 
-/** Flush all queued transactions by relaying them. */
+/** Check embargo timers and fluff expired transactions. */
 void FlushStemPool();
 
 }


### PR DESCRIPTION
## Summary
- implement embargo-based stem pool logic
- randomly choose outbound peers for stem relays
- flush expired stems to the network
- annotate call sites in `net.cpp`

## Testing
- `apt-get install -y qtbase5-dev libboost-all-dev` *(passed)*
- `cmake -S . -B build` *(failed: missing submodules)*
- `g++ -std=c++20 -I src -I . -c src/p2p/dandelion.cpp` *(failed: missing dependencies)*

