### PR TITLE
Enable BIP324 handshake with opt-out

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -368,6 +368,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), DEFAULT_PERMIT_BAREMULTISIG));
     strUsage += HelpMessageOpt("-peerbloomfilters", strprintf(_("Support filtering of blocks and transaction with bloom filters (default: %u)"), DEFAULT_PEERBLOOMFILTERS));
     strUsage += HelpMessageOpt("-dandelion", strprintf(_("Enable Dandelion++ transaction relay (default: %u)"), DEFAULT_DANDELION));
+    strUsage += HelpMessageOpt("-p2pnoencrypt", _("Disable BIP324 encrypted transport"));
     strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u or testnet: %u)"), Params(CBaseChainParams::MAIN).GetDefaultPort(), Params(CBaseChainParams::TESTNET).GetDefaultPort()));
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));
     strUsage += HelpMessageOpt("-proxyrandomize", strprintf(_("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)"), DEFAULT_PROXYRANDOMIZE));
@@ -1208,6 +1209,7 @@ bool AppInit2(Config& config, boost::thread_group& threadGroup, CScheduler& sche
     fNameLookup = GetBoolArg("-dns", DEFAULT_NAME_LOOKUP);
     fRelayTxes = !GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY);
     fDandelion = GetBoolArg("-dandelion", DEFAULT_DANDELION);
+    fBIP324 = !GetBoolArg("-p2pnoencrypt", false);
 
     bool fBound = false;
     if (fListen) {

--- a/src/net.h
+++ b/src/net.h
@@ -76,6 +76,8 @@ static const bool DEFAULT_BLOCKSONLY = false;
 
 /** Default for Dandelion++ transaction relay */
 static const bool DEFAULT_DANDELION = true;
+/** Default for encrypted transport (BIP324) */
+static const bool DEFAULT_P2P_ENCRYPT = true;
 
 static const bool DEFAULT_FORCEDNSSEED = false;
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
@@ -168,6 +170,7 @@ extern ServiceFlags nLocalServices;
 extern ServiceFlags nRelevantServices;
 extern bool fRelayTxes;
 extern bool fDandelion;
+extern bool fBIP324;
 extern uint64_t nLocalHostNonce;
 extern CAddrMan addrman;
 
@@ -216,6 +219,7 @@ public:
     uint64_t nRecvBytes;
     mapMsgCmdSize mapRecvBytesPerMsgCmd;
     bool fWhitelisted;
+    bool bip324;
     double dPingTime;
     double dPingWait;
     double dPingMin;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -119,6 +119,7 @@ UniValue getpeerinfo(const UniValue& params, bool fHelp)
             "       \"addr\": n,             (numeric) The total bytes received aggregated by message type\n"
             "       ...\n"
             "    }\n"
+            "    \"bip324\": true|false     (boolean) Whether encrypted transport was negotiated\n"
             "  }\n"
             "  ,...\n"
             "]\n"
@@ -174,6 +175,7 @@ UniValue getpeerinfo(const UniValue& params, bool fHelp)
             obj.push_back(Pair("inflight", heights));
         }
         obj.push_back(Pair("whitelisted", stats.fWhitelisted));
+        obj.push_back(Pair("bip324", stats.bip324));
 
         UniValue sendPerMsgCmd(UniValue::VOBJ);
         BOOST_FOREACH(const mapMsgCmdSize::value_type &i, stats.mapSendBytesPerMsgCmd) {


### PR DESCRIPTION
## Summary
- integrate `p2p::Handshake` with connection setup
- add `-p2pnoencrypt` flag to disable encrypted transport
- expose BIP324 status via `getpeerinfo`

## Testing
- `make -C src check` *(fails: No rule to make target 'Makefile.am', needed by 'Makefile.in')*

