### PR TITLE
Add Dandelion flag

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -65,6 +65,7 @@ The TheMinerzCoin repo's [root README](/README.md) contains relevant information
 - [Taproot and Schnorr](taproot_schnorr.md)
 - [Encrypted P2P Transport](encrypted_p2p_handshake.md)
 - [BLS12-381 Staking](bls12-381-staking.md)
+- [Dandelion++ Transaction Relay](dandelion.md)
 - [Dnsseed Policy](dnsseed-policy.md)
 - [Benchmarking](benchmarking.md)
 

--- a/doc/dandelion.md
+++ b/doc/dandelion.md
@@ -1,0 +1,7 @@
+# Dandelion++ Transaction Relay
+
+Dandelion++ obfuscates the origin of transactions by relaying them through a short "stem" phase before broadcasting them widely. This helps preserve user privacy against network observers.
+
+## Usage
+
+TheMinerzCoin enables Dandelion++ by default. To disable it, start the node with `-dandelion=0` or set `dandelion=0` in `theminerzcoin.conf`. Use `-dandelion=1` to explicitly turn it back on.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -367,7 +367,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), DEFAULT_PERMIT_BAREMULTISIG));
     strUsage += HelpMessageOpt("-peerbloomfilters", strprintf(_("Support filtering of blocks and transaction with bloom filters (default: %u)"), DEFAULT_PEERBLOOMFILTERS));
-    strUsage += HelpMessageOpt("-dandelion", strprintf(_("Enable Dandelion++ transaction relay (default: %u)"), DEFAULT_DANDELION));
+    strUsage += HelpMessageOpt("-dandelion=<n>", strprintf(_("Enable or disable Dandelion++ transaction relay (0-1, default: %u)"), DEFAULT_DANDELION));
     strUsage += HelpMessageOpt("-p2pnoencrypt", _("Disable BIP324 encrypted transport"));
     strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u or testnet: %u)"), Params(CBaseChainParams::MAIN).GetDefaultPort(), Params(CBaseChainParams::TESTNET).GetDefaultPort()));
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -88,7 +88,7 @@ bool fDiscover = true;
 bool fListen = true;
 ServiceFlags nLocalServices = NODE_NETWORK;
 bool fRelayTxes = true;
-// Enable experimental Dandelion++ transaction relay
+// Enable Dandelion++ transaction relay (controlled via -dandelion)
 bool fDandelion = DEFAULT_DANDELION;
 // Use BIP324 encrypted transport if enabled
 bool fBIP324 = DEFAULT_P2P_ENCRYPT;


### PR DESCRIPTION
## Summary
- document Dandelion++ relay and CLI flag
- reference the document from the main docs index
- show `-dandelion` usage in the help message
- clarify global variable comment for Dandelion++ relay

## Testing
- `./generate_build.sh`
- `./build.sh`

