### PR TITLE
docs: add Qt5 install steps

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,12 +6,19 @@ elements of the TheMinerzCoin reference implementation of TheMinerzCoin.
 
 Dependencies
 ------------
-Before building from source make sure the basic build tools are available. On
-most Linux systems these can be installed from the package manager:
+Before building from source make sure the basic build tools and Qt5 development
+packages are available. On recent Debian or Ubuntu systems run:
 
 ```
-sudo apt-get install build-essential cmake libssl-dev libevent-dev pkg-config
+sudo apt-get update
+sudo apt-get install build-essential cmake libssl-dev libevent-dev pkg-config \
+    qtbase5-dev qt5-qmake qttools5-dev qttools5-dev-tools libqt5widgets5 \
+    libqt5network5 libqt5gui5 libqt5core5a libqt5dbus5 libprotobuf-dev \
+    protobuf-compiler
 ```
+
+These packages provide OpenSSL, libevent, the Qt5 toolkit and Protocol Buffers
+so that `./generate_build.sh` can configure the build system without errors.
 
 Build Steps
 -----------


### PR DESCRIPTION
## Summary
- outline Debian/Ubuntu packages for Qt5 and build dependencies

## Testing
- `git status --short`

