### PR TITLE
Implement PoS slashing info RPC

### DIFF
--- a/doc/slashing.md
+++ b/doc/slashing.md
@@ -1,0 +1,31 @@
+# Slashing
+
+TheMinerzCoin introduces a lightweight proof-of-stake slashing system. Validators that sign conflicting blocks or remain offline for an extended period will see a portion of their stake reduced.
+
+## Validator behaviour
+
+- **Equivocation** – signing two different blocks for the same height results in an immediate penalty.
+- **Offline staking** – validators that do not produce blocks within the configured threshold are penalised.
+
+Slashed stakes are tracked internally. The wallet RPC command below exposes the current status.
+
+## RPC: `getslashinginfo`
+
+```
+getslashinginfo
+```
+
+Returns information about validators that have been slashed.
+
+Example output:
+
+```
+$ theminerzcoin-cli getslashinginfo
+[
+  {
+    "validator": "<validator id>",
+    "stake": 1000,
+    "slashed": 50
+  }
+]
+```

--- a/src/consensus/slashing.cpp
+++ b/src/consensus/slashing.cpp
@@ -1,0 +1,55 @@
+#include "slashing.h"
+#include "utiltime.h"
+#include "utilstrencodings.h"
+#include <map>
+
+namespace Consensus {
+
+static std::map<CKeyID, std::map<int64_t, uint256>> mapValidatorBlocks;
+static std::map<CKeyID, ValidatorStatus> mapValidatorStatus;
+
+static void SlashValidator(const CKeyID& validator, const char* reason)
+{
+    ValidatorStatus& st = mapValidatorStatus[validator];
+    CAmount penalty = st.stake / 10; // simple 10% penalty
+    st.stake -= penalty;
+    st.slashed += penalty;
+}
+
+void ReportValidatorBlock(const CKeyID& validator, int64_t height, const uint256& hash)
+{
+    ValidatorStatus& st = mapValidatorStatus[validator];
+    st.lastBlockTime = GetTime();
+
+    std::map<int64_t, uint256>& byHeight = mapValidatorBlocks[validator];
+    auto it = byHeight.find(height);
+    if (it != byHeight.end() && it->second != hash) {
+        SlashValidator(validator, "equivocation");
+    }
+    byHeight[height] = hash;
+}
+
+void CheckOfflineValidators(int64_t currentTime, int64_t offlineThreshold)
+{
+    for (auto& item : mapValidatorStatus) {
+        if (currentTime - item.second.lastBlockTime > offlineThreshold) {
+            SlashValidator(item.first, "offline");
+            item.second.lastBlockTime = currentTime;
+        }
+    }
+}
+
+UniValue GetSlashingInfo()
+{
+    UniValue result(UniValue::VARR);
+    for (const auto& it : mapValidatorStatus) {
+        UniValue obj(UniValue::VOBJ);
+        obj.pushKV("validator", HexStr(it.first.begin(), it.first.end()));
+        obj.pushKV("stake", it.second.stake);
+        obj.pushKV("slashed", it.second.slashed);
+        result.push_back(obj);
+    }
+    return result;
+}
+
+} // namespace Consensus

--- a/src/consensus/slashing.h
+++ b/src/consensus/slashing.h
@@ -1,0 +1,27 @@
+#ifndef BITCOIN_CONSENSUS_SLASHING_H
+#define BITCOIN_CONSENSUS_SLASHING_H
+
+#include "amount.h"
+#include "pubkey.h"
+#include <map>
+#include <stdint.h>
+#include <string>
+#include <univalue.h>
+#include <uint256.h>
+
+namespace Consensus {
+
+struct ValidatorStatus {
+    CAmount stake;
+    int64_t lastBlockTime;
+    CAmount slashed;
+    ValidatorStatus() : stake(0), lastBlockTime(0), slashed(0) {}
+};
+
+void ReportValidatorBlock(const CKeyID& validator, int64_t height, const uint256& hash);
+void CheckOfflineValidators(int64_t currentTime, int64_t offlineThreshold);
+UniValue GetSlashingInfo();
+
+} // namespace Consensus
+
+#endif // BITCOIN_CONSENSUS_SLASHING_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -14,6 +14,7 @@
 #include "main.h"
 #include "net.h"
 #include "pos.h"
+#include "consensus/slashing.h"
 #include "rpc/server.h"
 #include "timedata.h"
 #include "util.h"
@@ -2962,6 +2963,17 @@ static UniValue combineblssigs(const UniValue& params, bool fHelp)
     return HexStr(out.data.begin(), out.data.end());
 }
 
+static UniValue getslashinginfo(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "getslashinginfo\n"
+            "Return information about slashed validators.\n");
+
+    LOCK(cs_main);
+    return Consensus::GetSlashingInfo();
+}
+
 extern UniValue abortrescan(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue dumpprivkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue importprivkey(const UniValue& params, bool fHelp);
@@ -3024,6 +3036,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "walletpassphrase",         &walletpassphrase,         true  },
     { "wallet",             "removeprunedfunds",        &removeprunedfunds,        true  },
     { "wallet",             "burn",                     &burn,                     false },
+    { "wallet",             "getslashinginfo",          &getslashinginfo,   false },
     { "wallet",             "registerpool",             &registerpool,    true  },
     { "wallet",             "combineblssigs",           &combineblssigs,  true  },
     // ToDo: fix burnwallet


### PR DESCRIPTION
## Summary
- add new `slashing` module with simple penalty logic
- expose validator slashing info via new `getslashinginfo` RPC call
- document the feature in `doc/slashing.md`

## Testing
- `cmake --build build --target check` *(fails: build directory missing)*

