### PR TITLE
Add pilot Lightning bridge

### DIFF
--- a/doc/lightning.md
+++ b/doc/lightning.md
@@ -1,0 +1,39 @@
+# Lightning/State-Channels Bridge
+
+This pilot module allows `theminerzcoind` to interact with an external
+[LND](https://github.com/lightningnetwork/lnd) instance via gRPC. The
+feature is experimental and must be explicitly enabled at build time.
+
+## Building
+
+Enable the module by passing `-DWITH_LIGHTNING=ON` to CMake. The build
+expects gRPC and the LND protobuf definitions to be available on your
+system. Example:
+
+```bash
+cmake -DWITH_LIGHTNING=ON ..
+make
+```
+
+## Configuration
+
+Use the `-lndconnect` option to specify the gRPC address of your LND
+node. By default the client connects to `localhost:10009`.
+
+```
+theminerzcoind -lndconnect=127.0.0.1:10009
+```
+
+## Wallet RPC commands
+
+When built with lightning support three new wallet RPC commands become
+available:
+
+- `openchannel "node_pubkey" amount` – open a channel with `amount`
+  satoshis.
+- `closechannel "txid:index"` – close the specified channel.
+- `fundchannel "node_pubkey" amount` – create the funding transaction
+  but do not broadcast it.
+
+These commands delegate to the connected LND instance and return an
+error if the request fails.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,4 +22,9 @@ add_subdirectory(p2p)
 add_subdirectory(univalue)
 add_subdirectory(secp256k1)
 
+option(WITH_LIGHTNING "Build with Lightning support" OFF)
+if(WITH_LIGHTNING)
+    add_subdirectory(lightning)
+endif()
+
 add_subdirectory(test)

--- a/src/lightning/CMakeLists.txt
+++ b/src/lightning/CMakeLists.txt
@@ -1,0 +1,4 @@
+file(GLOB LIGHTNING_SOURCES *.cpp)
+add_library(lightning STATIC ${LIGHTNING_SOURCES})
+target_include_directories(lightning PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_link_libraries(lightning PUBLIC grpc++ grpc)

--- a/src/lightning/lightning_client.cpp
+++ b/src/lightning/lightning_client.cpp
@@ -1,0 +1,74 @@
+#include "lightning_client.h"
+
+#ifdef ENABLE_LIGHTNING
+#include <grpcpp/create_channel.h>
+#include <grpcpp/client_context.h>
+#include <lnrpc/lightning.pb.h>
+
+LightningClient::LightningClient(const std::string& uri)
+    : m_stub(lnrpc::Lightning::NewStub(grpc::CreateChannel(uri, grpc::InsecureChannelCredentials()))) {}
+
+bool LightningClient::openChannel(const std::string& pubkey, uint64_t amount, std::string& error)
+{
+    lnrpc::OpenChannelRequest req;
+    req.set_node_pubkey_string(pubkey);
+    req.set_local_funding_amount(amount);
+
+    lnrpc::ChannelPoint resp;
+    grpc::ClientContext ctx;
+    auto status = m_stub->OpenChannelSync(&ctx, req, &resp);
+    if (!status.ok()) {
+        error = status.error_message();
+        return false;
+    }
+    return true;
+}
+
+bool LightningClient::closeChannel(const std::string& cp, std::string& error)
+{
+    lnrpc::CloseChannelRequest req;
+    req.mutable_channel_point()->set_funding_txid_str(cp);
+    lnrpc::CloseStatusUpdate update;
+    grpc::ClientContext ctx;
+    std::unique_ptr<grpc::ClientReader<lnrpc::CloseStatusUpdate>> stream = m_stub->CloseChannel(&ctx, req);
+    if (!stream->Read(&update)) {
+        error = "no response";
+        return false;
+    }
+    auto status = stream->Finish();
+    if (!status.ok()) {
+        error = status.error_message();
+        return false;
+    }
+    return true;
+}
+
+bool LightningClient::fundChannel(const std::string& pubkey, uint64_t amount, std::string& txid, std::string& error)
+{
+    lnrpc::OpenChannelRequest req;
+    req.set_node_pubkey_string(pubkey);
+    req.set_local_funding_amount(amount);
+
+    lnrpc::ChannelPoint resp;
+    grpc::ClientContext ctx;
+    auto status = m_stub->OpenChannelSync(&ctx, req, &resp);
+    if (!status.ok()) {
+        error = status.error_message();
+        return false;
+    }
+    txid = resp.funding_txid_str();
+    return true;
+}
+
+#else
+
+LightningClient::LightningClient(const std::string&) {}
+
+bool LightningClient::openChannel(const std::string&, uint64_t, std::string&) { return false; }
+
+bool LightningClient::closeChannel(const std::string&, std::string&) { return false; }
+
+bool LightningClient::fundChannel(const std::string&, uint64_t, std::string&, std::string&) { return false; }
+
+#endif
+

--- a/src/lightning/lightning_client.h
+++ b/src/lightning/lightning_client.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#ifdef ENABLE_LIGHTNING
+#include <grpcpp/grpcpp.h>
+#include <lnrpc/lightning.grpc.pb.h>
+#endif
+
+class LightningClient
+{
+public:
+    explicit LightningClient(const std::string& server_uri);
+    bool openChannel(const std::string& pubkey, uint64_t amount, std::string& error);
+    bool closeChannel(const std::string& channel_point, std::string& error);
+    bool fundChannel(const std::string& pubkey, uint64_t amount, std::string& txid, std::string& error);
+private:
+#ifdef ENABLE_LIGHTNING
+    std::unique_ptr<lnrpc::Lightning::Stub> m_stub;
+#endif
+};

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -1,3 +1,8 @@
 file(GLOB WALLET_SOURCES *.cpp)
 add_library(wallet STATIC ${WALLET_SOURCES})
 target_include_directories(wallet PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+if(WITH_LIGHTNING)
+    target_link_libraries(wallet PUBLIC lightning)
+    target_compile_definitions(wallet PUBLIC ENABLE_LIGHTNING)
+endif()


### PR DESCRIPTION
## Summary
- add optional Lightning module
- expose openchannel/closechannel/fundchannel RPCs
- document how to use the pilot Lightning bridge

## Testing
- `cmake -DWITH_LIGHTNING=OFF -B build` *(fails: could not find Qt5)*

