### PR TITLE
Add compact block v2 negotiation

### DIFF
--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -17,8 +17,8 @@
 
 #define MIN_TRANSACTION_SIZE (::GetSerializeSize(CTransaction(), SER_NETWORK, PROTOCOL_VERSION))
 
-CBlockHeaderAndShortTxIDs::CBlockHeaderAndShortTxIDs(const CBlock& block) :
-        nonce(GetRand(std::numeric_limits<uint64_t>::max())),
+CBlockHeaderAndShortTxIDs::CBlockHeaderAndShortTxIDs(const CBlock& block, bool use_wtxid_in) :
+        nonce(GetRand(std::numeric_limits<uint64_t>::max())), use_wtxid(use_wtxid_in),
         shorttxids(block.vtx.size() - 1), prefilledtxn(1), header(block), vchBlockSig(block.vchBlockSig) {
     FillShortTxIDSelector();
     //TODO: Use our mempool prior to block acceptance to predictively fill more than just the coinbase
@@ -47,7 +47,7 @@ uint64_t CBlockHeaderAndShortTxIDs::GetShortID(const uint256& txhash) const {
 
 
 
-ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& cmpctblock) {
+ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& cmpctblock, bool use_wtxid) {
     if (cmpctblock.header.IsNull() || (cmpctblock.shorttxids.empty() && cmpctblock.prefilledtxn.empty()))
         return READ_STATUS_INVALID;
     if (cmpctblock.shorttxids.size() + cmpctblock.prefilledtxn.size() > MAX_BLOCK_SIZE / MIN_TRANSACTION_SIZE)

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -132,6 +132,7 @@ class CBlockHeaderAndShortTxIDs {
 private:
     mutable uint64_t shorttxidk0, shorttxidk1;
     uint64_t nonce;
+    bool use_wtxid;
 
     void FillShortTxIDSelector() const;
 
@@ -147,9 +148,11 @@ public:
     std::vector<unsigned char> vchBlockSig;
 
     // Dummy for deserialization
-    CBlockHeaderAndShortTxIDs() {}
+    CBlockHeaderAndShortTxIDs() : use_wtxid(false) {}
 
-    CBlockHeaderAndShortTxIDs(const CBlock& block);
+    CBlockHeaderAndShortTxIDs(const CBlock& block, bool use_wtxid_in = false);
+
+    void SetUseWTXID(bool flag) { use_wtxid = flag; }
 
     uint64_t GetShortID(const uint256& txhash) const;
 
@@ -202,7 +205,7 @@ public:
     std::vector<unsigned char> vchBlockSig;
     PartiallyDownloadedBlock(CTxMemPool* poolIn) : pool(poolIn) {}
 
-    ReadStatus InitData(const CBlockHeaderAndShortTxIDs& cmpctblock);
+    ReadStatus InitData(const CBlockHeaderAndShortTxIDs& cmpctblock, bool use_wtxid = false);
     bool IsTxAvailable(size_t index) const;
     ReadStatus FillBlock(CBlock& block, const std::vector<CTransaction>& vtx_missing) const;
 };


### PR DESCRIPTION
## Summary
- add compact block version tracking in peer state
- negotiate version 2 compact blocks when encrypted transport (BIP324) is used
- plumb compact block version info through message handling and creation

## Testing
- `./generate_build.sh` *(fails: Could not find a package configuration file provided by "Qt5")*

