### PR TITLE
Add assumeutxodat flag with stub handler

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -85,6 +85,12 @@ using node::BlockMap;
 using node::CBlockIndexHeightOnlyComparator;
 using node::CBlockIndexWorkComparator;
 using node::SnapshotMetadata;
+
+bool LoadAssumeutxoSnapshot(const std::string& path)
+{
+    LogPrintf("[snapshot] assumeutxodat not yet supported (%s)\n", path);
+    return false;
+}
 bool ValidateBRC20Transaction(const CBRC20Transaction& tx)
 {
     if (tx.amount <= 0) {


### PR DESCRIPTION
## Summary
- add `-assumeutxodat=<file>` CLI argument
- check for the snapshot file during init and call a stub loader
- stub out `LoadAssumeutxoSnapshot` in validation

## Testing
- `cmake ..` *(fails: could not find Qt5)*

