### PR TITLE
Document assume-utxo and compact block v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ Version 3.0 introduces:
 - Encrypted P2P transport (BIP324)
 - BLS aggregate signatures for staking pools
 - Dandelion++ transaction relay for improved privacy
+
+Usage
+-----
+Bootstrap a node from a UTXO snapshot by supplying the `-assumeutxodat` flag on
+startup:
+
+```
+theminerzd -assumeutxodat=/path/to/utxo-snapshot.dat
+```
+
+When peers communicate over the default BIP324 encrypted transport, block relay
+uses compact block **v2** automatically. Disable encryption with `-p2pnoencrypt`
+to fall back to version 1 if needed.
 Architecture
 ------------
 A high-level architecture diagram is provided in [docs/architecture.puml](docs/architecture.puml) illustrating the wallet, RPC, consensus and P2P layers as well as the new BLS staking module.

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -45,6 +45,10 @@ Notable changes
 P2P and network changes
 -----------------------
 
+- Compact block **v2** is now negotiated when peers communicate over the
+  encrypted BIP324 transport. This reduces bandwidth compared to version 1
+  while maintaining compatibility with unencrypted peers.
+
 New and Updated RPCs
 --------------------
 
@@ -56,6 +60,10 @@ Files
 
 New settings
 ------------
+
+- `-assumeutxodat=<file>` can be used to bootstrap from a UTXO snapshot at
+  startup. This option loads the specified snapshot as the initial chainstate
+  and significantly shortens the time required for first synchronization.
 
 Updated settings
 ----------------


### PR DESCRIPTION
## Summary
- add usage instructions for assumeutxo snapshots and compact block v2
- document new `-assumeutxodat` flag and compact block v2 support in the release notes

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt5")*

