### PR TITLE
Add zk rollup scaffolding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,11 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+option(ENABLE_ZK_ROLLUP "Enable zk rollup support" OFF)
+if(ENABLE_ZK_ROLLUP)
+    add_definitions(-DENABLE_ZK_ROLLUP)
+endif()
+
 add_subdirectory(src/leveldb)
 add_subdirectory(src/crc32c)
 add_subdirectory(src)

--- a/docs/rollup_design.md
+++ b/docs/rollup_design.md
@@ -1,0 +1,17 @@
+# Rollup Architecture Overview
+
+This document outlines the proposed design for integrating a high-TPS sidechain using a rollup mechanism.
+
+## Components
+
+- **BlockCommitment**: Records commitments of aggregated transactions that will later be proven on the main chain.
+- **ProofVerifier**: Handles zero-knowledge proof verification for state transitions.
+
+## Flow
+
+1. Transactions are collected off-chain and batched into a rollup block.
+2. `BlockCommitment` stores a lightweight commitment to this batch on-chain.
+3. A zero-knowledge proof is generated off-chain and submitted with the commitment.
+4. `ProofVerifier` validates the proof, finalizing the rollup block.
+
+This architecture allows many off-chain transactions while retaining security through succinct proofs.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,4 +27,8 @@ if(WITH_LIGHTNING)
     add_subdirectory(lightning)
 endif()
 
+if(ENABLE_ZK_ROLLUP)
+    add_subdirectory(rollup)
+endif()
+
 add_subdirectory(test)

--- a/src/rollup/CMakeLists.txt
+++ b/src/rollup/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB ROLLUP_SOURCES *.cpp)
+add_library(rollup STATIC ${ROLLUP_SOURCES})
+target_include_directories(rollup PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/src/rollup/block_commitment.cpp
+++ b/src/rollup/block_commitment.cpp
@@ -1,0 +1,5 @@
+#include "block_commitment.h"
+
+void BlockCommitment::record() {
+    // TODO: Implement commitment recording logic
+}

--- a/src/rollup/block_commitment.h
+++ b/src/rollup/block_commitment.h
@@ -1,0 +1,11 @@
+#ifndef THEMZ_ROLLUP_BLOCK_COMMITMENT_H
+#define THEMZ_ROLLUP_BLOCK_COMMITMENT_H
+
+class BlockCommitment {
+public:
+    // Placeholder for block commitment data and operations
+    BlockCommitment() = default;
+    void record();
+};
+
+#endif // THEMZ_ROLLUP_BLOCK_COMMITMENT_H

--- a/src/rollup/proof_verifier.cpp
+++ b/src/rollup/proof_verifier.cpp
@@ -1,0 +1,6 @@
+#include "proof_verifier.h"
+
+bool ProofVerifier::verify() {
+    // TODO: Implement zk proof verification
+    return false;
+}

--- a/src/rollup/proof_verifier.h
+++ b/src/rollup/proof_verifier.h
@@ -1,0 +1,11 @@
+#ifndef THEMZ_ROLLUP_PROOF_VERIFIER_H
+#define THEMZ_ROLLUP_PROOF_VERIFIER_H
+
+class ProofVerifier {
+public:
+    // Placeholder for zk proof verification
+    ProofVerifier() = default;
+    bool verify();
+};
+
+#endif // THEMZ_ROLLUP_PROOF_VERIFIER_H


### PR DESCRIPTION
## Summary
- add ENABLE_ZK_ROLLUP cmake option
- create rollup library with placeholder classes
- describe architecture for the sidechain rollup

## Testing
- `cmake ..` *(fails: add_subdirectory given source "third_party/googletest" which is not an existing directory)*

