### PR TITLE
Add additional fuzz targets and OSS-Fuzz setup

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -14,3 +14,17 @@ jobs:
       run: cmake --build build -j2
     - name: Test
       run: cmake --build build --target check
+
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Configure fuzzers
+      run: cmake -S . -B fuzz_build -DCMAKE_CXX_FLAGS="-fsanitize=fuzzer,address" -DCMAKE_C_FLAGS="-fsanitize=fuzzer,address"
+    - name: Build fuzzers
+      run: cmake --build fuzz_build -j2 --target tx_deser_fuzz block_deser_fuzz script_interpreter_fuzz
+    - name: Run fuzzers
+      run: |
+        ./fuzz_build/src/test/fuzz/tx_deser_fuzz -runs=1
+        ./fuzz_build/src/test/fuzz/block_deser_fuzz -runs=1
+        ./fuzz_build/src/test/fuzz/script_interpreter_fuzz -runs=1

--- a/contrib/oss-fuzz/Dockerfile
+++ b/contrib/oss-fuzz/Dockerfile
@@ -1,0 +1,11 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y cmake build-essential
+
+COPY . $SRC/TheMinerzCoin
+WORKDIR $SRC/TheMinerzCoin
+
+RUN cmake -S . -B build -DCMAKE_CXX_FLAGS="-fsanitize=fuzzer,address" -DCMAKE_C_FLAGS="-fsanitize=fuzzer,address"
+RUN cmake --build build -j$(nproc) --target tx_deser_fuzz block_deser_fuzz script_interpreter_fuzz
+
+RUN cp build/src/test/fuzz/*_fuzz $OUT/

--- a/src/test/fuzz/CMakeLists.txt
+++ b/src/test/fuzz/CMakeLists.txt
@@ -1,2 +1,8 @@
 add_executable(tx_deser_fuzz transaction_deserialize.cpp)
 target_include_directories(tx_deser_fuzz PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../)
+
+add_executable(block_deser_fuzz block_deserialize.cpp)
+target_include_directories(block_deser_fuzz PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../)
+
+add_executable(script_interpreter_fuzz script_interpreter.cpp)
+target_include_directories(script_interpreter_fuzz PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../)

--- a/src/test/fuzz/block_deserialize.cpp
+++ b/src/test/fuzz/block_deserialize.cpp
@@ -1,0 +1,15 @@
+#include "primitives/block.h"
+#include "streams.h"
+#include "version.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    try {
+        CDataStream stream((const char*)data, (const char*)data + size, SER_NETWORK, PROTOCOL_VERSION);
+        CBlock block;
+        stream >> block;
+    } catch (const std::exception&) {
+        // ignore deserialization errors
+    }
+    return 0;
+}

--- a/src/test/fuzz/script_interpreter.cpp
+++ b/src/test/fuzz/script_interpreter.cpp
@@ -1,0 +1,13 @@
+#include "script/interpreter.h"
+#include "script/script.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    size_t half = size / 2;
+    CScript scriptSig(data, data + half);
+    CScript scriptPubKey(data + half, data + size);
+    ScriptError err;
+    BaseSignatureChecker checker;
+    VerifyScript(scriptSig, scriptPubKey, SCRIPT_VERIFY_NONE, checker, &err);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add block and script interpreter fuzzers
- integrate fuzz builds with ASan in CI
- provide OSS-Fuzz compatible Dockerfile

## Testing
- `cmake -S . -B build` *(fails: could not find a package configuration file provided by "Qt5")*

