### PR TITLE
Add metrics endpoint and Grafana dashboard

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,22 @@
+# Metrics and Monitoring
+
+The node exposes a Prometheus compatible endpoint at `/metrics` once built with the `prometheus-cpp` library available.
+
+## Building
+
+Ensure `prometheus-cpp` is installed and discoverable by CMake. Regenerate the build files and compile normally:
+
+```bash
+./generate_build.sh
+./build.sh
+```
+
+## Running
+
+Start the daemon as usual. Metrics are served over the existing HTTP server on the same port as RPC.
+
+Visit `http://<node-host>:8332/metrics` to scrape metrics.
+
+## Grafana
+
+Import the dashboard JSON in the `grafana/` directory to visualize common node statistics.

--- a/grafana/node.json
+++ b/grafana/node.json
@@ -1,0 +1,22 @@
+{
+  "title": "TheMinerzCoin Node",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Chain Height",
+      "targets": [{"expr": "node_chain_height", "legendFormat": "height"}]
+    },
+    {
+      "type": "graph",
+      "title": "Peer Count",
+      "targets": [{"expr": "node_peer_count", "legendFormat": "peers"}]
+    },
+    {
+      "type": "graph",
+      "title": "Mempool Transactions",
+      "targets": [{"expr": "node_mempool_tx", "legendFormat": "tx"}]
+    }
+  ],
+  "schemaVersion": 16,
+  "version": 1
+}

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -31,6 +31,7 @@
 #include "grpc/node_service.h"
 #include "websockets/events.h"
 #include "script/standard.h"
+#include "rpc/metrics.h"
 #include "script/sigcache.h"
 #include "scheduler.h"
 #include "txdb.h"
@@ -204,6 +205,7 @@ void Shutdown()
     StopGraphQLServer();
     StopNodeGrpcServer();
     StopWebSocketServer();
+    StopMetricsServer();
     StopRPC();
     StopHTTPServer();
 #ifdef ENABLE_WALLET
@@ -712,6 +714,7 @@ bool AppInitServers(boost::thread_group& threadGroup)
     StartGraphQLServer();
     StartNodeGrpcServer("0.0.0.0:50051");
     StartWebSocketServer(12345);
+    StartMetricsServer();
     if (!StartHTTPServer())
         return false;
     return true;

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -1,3 +1,4 @@
 file(GLOB RPC_SOURCES *.cpp)
 add_library(rpc STATIC ${RPC_SOURCES})
 target_include_directories(rpc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_link_libraries(rpc PUBLIC prometheus-cpp-core)

--- a/src/rpc/metrics.cpp
+++ b/src/rpc/metrics.cpp
@@ -1,0 +1,55 @@
+#include "httpserver.h"
+#include "metrics.h"
+#include "main.h"
+#include "net.h"
+#include "txmempool.h"
+#include <prometheus/registry.h>
+#include <prometheus/gauge.h>
+#include <prometheus/text_serializer.h>
+#include <memory>
+
+using namespace prometheus;
+
+static std::shared_ptr<Registry> registry;
+static Gauge* chain_height = nullptr;
+static Gauge* peer_count = nullptr;
+static Gauge* mempool_tx = nullptr;
+
+static bool HTTPReq_Metrics(HTTPRequest* req, const std::string&)
+{
+    if (req->GetRequestMethod() != HTTPRequest::GET) {
+        req->WriteReply(HTTP_BAD_METHOD, "Metrics requires GET");
+        return false;
+    }
+    if (!registry) {
+        registry = std::make_shared<Registry>();
+        auto& fam = BuildGauge().Name("node_chain_height").Help("Current block height").Register(*registry);
+        chain_height = &fam.Add({});
+        auto& fam2 = BuildGauge().Name("node_peer_count").Help("Connected peers").Register(*registry);
+        peer_count = &fam2.Add({});
+        auto& fam3 = BuildGauge().Name("node_mempool_tx").Help("Mempool transactions").Register(*registry);
+        mempool_tx = &fam3.Add({});
+    }
+    chain_height->Set(chainActive.Height());
+    {
+        LOCK(cs_vNodes);
+        peer_count->Set(vNodes.size());
+    }
+    mempool_tx->Set(mempool.size());
+
+    TextSerializer serializer;
+    std::string body = serializer.Serialize(registry->Collect());
+    req->WriteHeader("Content-Type", "text/plain; version=0.0.4");
+    req->WriteReply(HTTP_OK, body);
+    return true;
+}
+
+void StartMetricsServer()
+{
+    RegisterHTTPHandler("/metrics", true, HTTPReq_Metrics);
+}
+
+void StopMetricsServer()
+{
+    UnregisterHTTPHandler("/metrics", true);
+}

--- a/src/rpc/metrics.h
+++ b/src/rpc/metrics.h
@@ -1,0 +1,3 @@
+#pragma once
+void StartMetricsServer();
+void StopMetricsServer();


### PR DESCRIPTION
## Summary
- expose Prometheus metrics at `/metrics`
- wire metrics server into init/startup and shutdown
- link rpc module with `prometheus-cpp`
- provide sample Grafana dashboard
- document metrics deployment steps

## Testing
- `./generate_build.sh` *(fails: Could not find package configuration file provided by "Qt5")*

------
https://chatgpt.com/codex/tasks/task_e_6867fb72e670832c9c1a3245e42e494b