### PR TITLE
Implement simple rollup commitment and verifier

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -101,6 +101,7 @@ BITCOIN_TESTS =\
   test/bls_tests.cpp
   test/dandelion_tests.cpp
   test/assumeutxo_tests.cpp
+  test/rollup_tests.cpp
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \

--- a/src/rollup/block_commitment.cpp
+++ b/src/rollup/block_commitment.cpp
@@ -1,5 +1,8 @@
 #include "block_commitment.h"
+#include "hash.h"
 
-void BlockCommitment::record() {
-    // TODO: Implement commitment recording logic
+void BlockCommitment::record(std::span<const unsigned char> block_data)
+{
+    uint256 commitment = Hash(block_data.begin(), block_data.end());
+    m_commitments.push_back(commitment);
 }

--- a/src/rollup/block_commitment.h
+++ b/src/rollup/block_commitment.h
@@ -1,11 +1,22 @@
 #ifndef THEMZ_ROLLUP_BLOCK_COMMITMENT_H
 #define THEMZ_ROLLUP_BLOCK_COMMITMENT_H
 
+#include <vector>
+#include <span>
+#include "uint256.h"
+
 class BlockCommitment {
 public:
-    // Placeholder for block commitment data and operations
     BlockCommitment() = default;
-    void record();
+
+    /** Store a commitment for the provided rollup block data. */
+    void record(std::span<const unsigned char> block_data);
+
+    /** Return all recorded commitments (for testing). */
+    const std::vector<uint256>& GetCommitments() const { return m_commitments; }
+
+private:
+    std::vector<uint256> m_commitments{};
 };
 
 #endif // THEMZ_ROLLUP_BLOCK_COMMITMENT_H

--- a/src/rollup/proof_verifier.cpp
+++ b/src/rollup/proof_verifier.cpp
@@ -1,6 +1,8 @@
 #include "proof_verifier.h"
+#include "hash.h"
 
-bool ProofVerifier::verify() {
-    // TODO: Implement zk proof verification
-    return false;
+bool ProofVerifier::verify(const uint256& commitment, std::span<const unsigned char> proof)
+{
+    uint256 proof_hash = Hash(proof.begin(), proof.end());
+    return proof_hash == commitment;
 }

--- a/src/rollup/proof_verifier.h
+++ b/src/rollup/proof_verifier.h
@@ -1,11 +1,19 @@
 #ifndef THEMZ_ROLLUP_PROOF_VERIFIER_H
 #define THEMZ_ROLLUP_PROOF_VERIFIER_H
 
+#include <span>
+#include "uint256.h"
+
 class ProofVerifier {
 public:
-    // Placeholder for zk proof verification
     ProofVerifier() = default;
-    bool verify();
+
+    /**
+     * Verify a zero-knowledge proof against a stored commitment.
+     * In this toy implementation the proof is hashed and compared
+     * against the commitment value.
+     */
+    bool verify(const uint256& commitment, std::span<const unsigned char> proof);
 };
 
 #endif // THEMZ_ROLLUP_PROOF_VERIFIER_H

--- a/src/test/rollup_tests.cpp
+++ b/src/test/rollup_tests.cpp
@@ -1,0 +1,21 @@
+#include <boost/test/unit_test.hpp>
+#include "rollup/block_commitment.h"
+#include "rollup/proof_verifier.h"
+
+BOOST_AUTO_TEST_SUITE(rollup_tests)
+
+BOOST_AUTO_TEST_CASE(commit_and_verify)
+{
+    BlockCommitment bc;
+    std::vector<unsigned char> data{'h','e','l','l','o'};
+    bc.record(data);
+    BOOST_REQUIRE_EQUAL(bc.GetCommitments().size(), 1u);
+
+    ProofVerifier verifier;
+    BOOST_CHECK(verifier.verify(bc.GetCommitments()[0], data));
+
+    std::vector<unsigned char> wrong{'b','a','d'};
+    BOOST_CHECK(!verifier.verify(bc.GetCommitments()[0], wrong));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- add vector-based commitment storage
- verify proofs by hashing and comparing
- expose basic rollup tests

## Testing
- `./build.sh` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68680673f4f8832c8a139c3f27729456