### PR TITLE
Add CBRC20Transaction support

### DIFF
--- a/src/primitives/brc20transaction.cpp
+++ b/src/primitives/brc20transaction.cpp
@@ -1,0 +1,13 @@
+#include "primitives/brc20transaction.h"
+
+CBRC20Transaction::CBRC20Transaction() : CTransaction(), tokenType(), amount(0) {}
+
+CBRC20Transaction::CBRC20Transaction(const CMutableBRC20Transaction& tx)
+    : CTransaction(tx), tokenType(tx.tokenType), amount(tx.amount) {}
+
+CMutableBRC20Transaction::CMutableBRC20Transaction()
+    : CMutableTransaction(), tokenType(), amount(0) {}
+
+CMutableBRC20Transaction::CMutableBRC20Transaction(const CBRC20Transaction& tx)
+    : CMutableTransaction(tx), tokenType(tx.tokenType), amount(tx.amount) {}
+

--- a/src/primitives/brc20transaction.h
+++ b/src/primitives/brc20transaction.h
@@ -1,0 +1,56 @@
+#ifndef BITCOIN_PRIMITIVES_BRC20TRANSACTION_H
+#define BITCOIN_PRIMITIVES_BRC20TRANSACTION_H
+
+#include "primitives/transaction.h"
+#include "serialize.h"
+#include <string>
+struct CMutableBRC20Transaction;
+
+/**
+ * Simple transaction representation for BRC20 token transfers.
+ * Extends CTransaction with token metadata.
+ */
+class CBRC20Transaction : public CTransaction
+{
+public:
+    std::string tokenType; //! Token ticker or identifier
+    CAmount amount{0};     //! Amount of token transferred
+
+    CBRC20Transaction();
+    CBRC20Transaction(const CMutableBRC20Transaction& tx);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
+        CTransaction::SerializationOp(s, ser_action, nType, nVersion);
+        READWRITE(tokenType);
+        READWRITE(amount);
+        if (ser_action.ForRead()) {
+            UpdateHash();
+        }
+    }
+};
+
+/** Mutable version of CBRC20Transaction. */
+struct CMutableBRC20Transaction : public CMutableTransaction
+{
+    std::string tokenType;
+    CAmount amount{0};
+
+    CMutableBRC20Transaction();
+    CMutableBRC20Transaction(const CBRC20Transaction& tx);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
+        CMutableTransaction::SerializationOp(s, ser_action, nType, nVersion);
+        READWRITE(tokenType);
+        READWRITE(amount);
+    }
+};
+
+#endif // BITCOIN_PRIMITIVES_BRC20TRANSACTION_H

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -271,6 +271,8 @@ public:
 
     CTransaction& operator=(const CTransaction& tx);
 
+    virtual ~CTransaction() = default;
+
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(fuzz)
 file(GLOB TEST_SOURCES *.cpp)
 add_executable(theminerzcoin_test ${TEST_SOURCES})
-target_link_libraries(theminerzcoin_test PUBLIC core node)
+target_link_libraries(theminerzcoin_test PUBLIC core node primitives)
 enable_testing()
 add_test(NAME assumeutxo COMMAND theminerzcoin_test)

--- a/src/test/brc20transaction_tests.cpp
+++ b/src/test/brc20transaction_tests.cpp
@@ -1,0 +1,23 @@
+#include <primitives/brc20transaction.h>
+#include <boost/test/unit_test.hpp>
+#include <test/test_bitcoin.h>
+
+bool ValidateTransaction(const CTransaction& tx);
+
+BOOST_FIXTURE_TEST_SUITE(brc20_transaction_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(brc20_validate_basic)
+{
+    CMutableBRC20Transaction mut;
+    mut.tokenType = "TEST";
+    mut.amount = 10;
+    CBRC20Transaction tx(mut);
+
+    BOOST_CHECK(ValidateTransaction(tx));
+
+    mut.amount = 0;
+    CBRC20Transaction bad(mut);
+    BOOST_CHECK(!ValidateTransaction(bad));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -39,6 +39,7 @@
 #include <pow.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <primitives/brc20transaction.h>
 #include <random.h>
 #include <script/script.h>
 #include <script/sigcache.h>
@@ -121,10 +122,11 @@ bool ValidateBRC20Transaction(const CBRC20Transaction& tx)
 
 bool ValidateTransaction(const CTransaction& tx)
 {
-    if (!tx.tokenType.empty()) {
-        return ValidateBRC20Transaction(static_cast<const CBRC20Transaction&>(tx));
+    const CBRC20Transaction* brc20 = dynamic_cast<const CBRC20Transaction*>(&tx);
+    if (brc20 && !brc20->tokenType.empty()) {
+        return ValidateBRC20Transaction(*brc20);
     }
-    // Standard-Transaktionsvalidierung
+    // Standard transaction validation (placeholder)
     return true;
 }
 /** Time to wait between writing blocks/block index to disk. */


### PR DESCRIPTION
## Summary
- add a CBRC20Transaction class with serialization
- extend CTransaction with a virtual destructor
- validate BRC20 transactions via dynamic casting
- link primitives in test build and add new unit test

## Testing
- `apt-get install -y qtbase5-dev`
- `./generate_build.sh -DWITH_GUI=OFF -DCRC32C_BUILD_TESTS=OFF -DCRC32C_BUILD_BENCHMARKS=OFF` *(fails: add_subdirectory errors)*

------
https://chatgpt.com/codex/tasks/task_e_686809096470832ca031329c52d3ccc8