### PR TITLE
Add GraphQL and Prometheus documentation

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -61,6 +61,8 @@ The TheMinerzCoin repo's [root README](/README.md) contains relevant information
 - [RPC/REST OpenAPI Specification](../specs/openapi.yaml)
 - [GraphQL Schema](../specs/schema.graphql)
 - [GraphQL API](../docs/graphql.md)
+- [GraphQL Server](graphql-server.md)
+- [Prometheus Metrics](prometheus-metrics.md)
 - [Shared Libraries](shared-libraries.md)
 - [BIPS](bips.md)
 - [Taproot and Schnorr](taproot_schnorr.md)

--- a/doc/graphql-server.md
+++ b/doc/graphql-server.md
@@ -1,0 +1,13 @@
+# GraphQL Server
+
+The node exposes a GraphQL endpoint at `/graphql` using the built-in HTTP server. It is enabled automatically when `theminerzcoind` starts and runs on the same port as RPC (default `8332`).
+
+## Querying
+
+Send HTTP `POST` requests containing a GraphQL document to the `/graphql` path. For example:
+
+```bash
+curl --data '{ block(height: 1) { hash height } }' http://localhost:8332/graphql
+```
+
+The available operations reflect the RPC API and are defined in [../specs/schema.graphql](../specs/schema.graphql). A short overview is also provided in [docs/graphql.md](../docs/graphql.md).

--- a/doc/prometheus-metrics.md
+++ b/doc/prometheus-metrics.md
@@ -1,0 +1,16 @@
+# Prometheus Metrics
+
+When built with the `prometheus-cpp` library available, the daemon exposes a `/metrics` endpoint for Prometheus scraping.
+
+## Building
+
+Install `prometheus-cpp` and regenerate the build files. Then compile as usual:
+
+```bash
+./generate_build.sh
+./build.sh
+```
+
+## Scraping
+
+Start `theminerzcoind` normally and visit `http://<node-host>:8332/metrics` to collect metrics. See [docs/metrics.md](../docs/metrics.md) for additional details and a Grafana dashboard.


### PR DESCRIPTION
## Summary
- document how to use the GraphQL server
- document how to scrape Prometheus metrics
- link new docs from the main README

## Testing
- `./generate_build.sh` *(fails: missing Qt5)*

