### PR TITLE
Add WebSocket event server docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,5 @@ The RPC/REST API—covering wallet management, staking operations and network
 statistics—is documented in [specs/openapi.yaml](specs/openapi.yaml). A prototype
 GraphQL schema describing the same functionality lives in
 [specs/schema.graphql](specs/schema.graphql).
+A lightweight WebSocket event server is also available; see
+[doc/websockets.md](doc/websockets.md).

--- a/doc/README.md
+++ b/doc/README.md
@@ -62,6 +62,7 @@ The TheMinerzCoin repo's [root README](/README.md) contains relevant information
 - [GraphQL Schema](../specs/schema.graphql)
 - [GraphQL API](../docs/graphql.md)
 - [GraphQL Server](graphql-server.md)
+- [WebSocket Event Server](websockets.md)
 - [Prometheus Metrics](prometheus-metrics.md)
 - [Shared Libraries](shared-libraries.md)
 - [BIPS](bips.md)

--- a/doc/websockets.md
+++ b/doc/websockets.md
@@ -1,0 +1,29 @@
+# WebSocket Event Server
+
+The node exposes a lightweight WebSocket endpoint broadcasting block and transaction events.
+It starts automatically when `theminerzd` runs and binds to port `12345` by default.
+
+## Running
+
+Start the daemon normally. If compiled with `libwebsockets`, the event server
+listens on `ws://<node-host>:12345` with no further configuration.
+
+## Configuration
+
+The port is currently fixed in `src/init.cpp`. Adjust it before building if a
+different value is required.
+
+## Example
+
+Connect using a WebSocket client such as `websocat`:
+
+```bash
+websocat ws://localhost:12345
+```
+
+Notifications use the following formats:
+
+```
+block:<hash>
+tx:<hash>
+```


### PR DESCRIPTION
## Summary
- document the WebSocket event server in `doc/websockets.md`
- link to the new document from `README.md` and `doc/README.md`

## Testing
- `./generate_build.sh` *(fails: could not find Qt5)*
- `cmake --build build --target check` *(fails: no Makefile)*

