### PR TITLE
Add gRPC node service docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,5 @@ GraphQL schema describing the same functionality lives in
 [specs/schema.graphql](specs/schema.graphql).
 A lightweight WebSocket event server is also available; see
 [doc/websockets.md](doc/websockets.md).
+A simple gRPC node service can also be started; see
+[doc/grpc-node-service.md](doc/grpc-node-service.md).

--- a/doc/README.md
+++ b/doc/README.md
@@ -64,6 +64,7 @@ The TheMinerzCoin repo's [root README](/README.md) contains relevant information
 - [GraphQL Server](graphql-server.md)
 - [WebSocket Event Server](websockets.md)
 - [Prometheus Metrics](prometheus-metrics.md)
+- [Node gRPC Service](grpc-node-service.md)
 - [Shared Libraries](shared-libraries.md)
 - [BIPS](bips.md)
 - [Taproot and Schnorr](taproot_schnorr.md)

--- a/doc/grpc-node-service.md
+++ b/doc/grpc-node-service.md
@@ -1,0 +1,23 @@
+# Node gRPC Service
+
+The node exposes a minimal gRPC server for accessing blockchain data and
+broadcasting transactions. It starts automatically when the daemon
+invokes `StartNodeGrpcServer`.
+
+## Running
+
+`StartNodeGrpcServer("0.0.0.0:50051")` is called during initialization
+from [`src/init.cpp`](../src/init.cpp). Launch `theminerzcoind` normally
+and the service will listen on port `50051`.
+
+## RPCs
+
+The service currently implements two RPC methods:
+
+- **GetBlock** – returns the hash and height of the block at a given
+  height.
+- **BroadcastTransaction** – broadcasts a raw transaction provided in
+  hex.
+
+The full protocol definition is available in
+[../specs/node.proto](../specs/node.proto).


### PR DESCRIPTION
## Summary
- document the gRPC node service and how to start it
- link gRPC docs from the doc index
- reference gRPC node service from the main README

## Testing
- `true`

