### PR TITLE
Add missing docker build script

### DIFF
--- a/contrib/docker/gh-build.sh
+++ b/contrib/docker/gh-build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME=${IMAGE_NAME:-theminerzcoin}
+TAG=${GIT_CURRENT_BRANCH:-latest}
+
+# Build Docker image
+
+docker build -t "${IMAGE_NAME}:${TAG}" -f docker/Dockerfile .
+
+# Push Docker image
+
+docker push "${IMAGE_NAME}:${TAG}"
+


### PR DESCRIPTION
## Summary
- add `contrib/docker/gh-build.sh` as referenced by workflow

## Testing
- `bash contrib/docker/gh-build.sh` *(fails: `docker` command not found)*

