### PR TITLE
Update docs for v3.0 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 - BLS aggregate staking
 - Dandelion++ transaction relay
 - Descriptor key management and PSBTv2 support
+- Compact Block v2 and assume-utxo
+- Lightning channel pilot via LND
+- Experimental zk-rollups sidechain
+- CMake build with C++20 modules
+- Fuzzing targets and sanitizer CI
+- Rust secp256k1 bindings
+- Hardware wallet interface
+- GraphQL/gRPC/WebSocket APIs
+- Neutrino SPV light client
+- Docker release images and Prometheus metrics
+- OpenAPI 3.1 specification
 
 ## v2.0.2 (2024-11-12)
 - Working Transaction Hotfix: Displays correct Timestamp in Explorer

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Version 3.0 introduces:
 - BLS aggregate signatures for staking pools
 - Dandelion++ transaction relay for improved privacy
 - Lightweight slashing to penalise equivocation and offline validators ([doc/slashing.md](doc/slashing.md))
+- Compact Block **v2** and assume-utxo snapshots for faster syncing
+- Optional Lightning channels via an LND bridge ([doc/lightning.md](doc/lightning.md))
+- Experimental zk-rollup sidechain ([docs/rollup_design.md](docs/rollup_design.md))
+- Modularised CMake build using C++20 features (`std::span`, `std::simd`)
+- Fuzz targets and sanitizer-based CI ([doc/fuzzing.md](doc/fuzzing.md))
+- Rust bindings for critical crypto routines under `rust/`
+- Descriptor wallets and PSBTv2 support ([doc/descriptor-wallets.md](doc/descriptor-wallets.md))
+- Native hardware wallet interface ([doc/hardware-wallets.md](doc/hardware-wallets.md))
+- GraphQL/gRPC APIs and WebSocket event streams
+- Neutrino SPV light client mode ([doc/neutrino.md](doc/neutrino.md))
+- Docker release images and Prometheus metrics ([docs/metrics.md](docs/metrics.md))
+- OpenAPI 3.1 specification for RPC/REST ([specs/openapi.yaml](specs/openapi.yaml))
 
 Usage
 -----

--- a/docs/RELEASE_NOTES_3.0.md
+++ b/docs/RELEASE_NOTES_3.0.md
@@ -6,6 +6,17 @@ Major Features
 - Encrypted P2P transport via BIP324
 - BLS12-381 aggregate signatures for staking pools
 - Dandelion++ transaction relay for improved privacy
+- Compact Block v2 and assume-utxo snapshots for faster initial sync
+- Optional Lightning channels through an LND bridge
+- zk-rollup sidechain prototype
+- Modularised CMake build system with C++20 (`std::span`, `std::simd`)
+- Fuzzing targets and sanitizer enabled CI
+- Rust bindings for secp256k1 based cryptography
+- Descriptor wallets, PSBTv2 and native hardware wallet support
+- GraphQL/gRPC APIs and WebSocket events
+- Neutrino SPV light client mode
+- Docker release images and Prometheus metrics
+- OpenAPI 3.1 specification for RPC/REST
 
 This release bumps the network protocol and database versions. Upgrading nodes
 will perform a one-time reindex.


### PR DESCRIPTION
## Summary
- expand README feature list for v3.0
- detail additional functionality in 3.0 release notes
- record new highlights in `CHANGELOG`

## Testing
- `./generate_build.sh && ./build.sh` *(fails: could not find Qt5)*
