### PR TITLE
Add lint configs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+DerivePointerAlignment: false
+AllowShortFunctionsOnASingleLine: Inline
+Standard: c++17

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: '-*,modernize-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+FormatStyle: none

--- a/logs/auto_build_log.md
+++ b/logs/auto_build_log.md
@@ -1,0 +1,5 @@
+Log #1: Initial repo structure and dependencies logged.
+Log #2: Technologies identified.
+Step 3: Added clang-format, clang-tidy, rustfmt, ruff config.
+Step 5: depends build failed (missing permissions).
+Build and tests skipped due to missing deps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,5 @@ line-length = 88
 line-length = 88
 
 [tool.ruff.lint]
-select = ["E", "F"]
-ignore = []
+select = ["E", "F", "I"]
+ignore = ["E501"]

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 100
+edition = "2021"


### PR DESCRIPTION
## Summary
- add clang-format and clang-tidy config
- add rustfmt config
- extend ruff lint configuration
- add auto build log

## Testing
- `clang-format --version`
- `rustfmt --version`

