### PR TITLE
Fix daemon name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Bootstrap a node from a UTXO snapshot by supplying the `-assumeutxodat` flag on
 startup:
 
 ```
-theminerzd -assumeutxodat=/path/to/utxo-snapshot.dat
+theminerzcoind -assumeutxodat=/path/to/utxo-snapshot.dat
 ```
 
 When peers communicate over the default BIP324 encrypted transport, block relay

--- a/doc/websockets.md
+++ b/doc/websockets.md
@@ -1,7 +1,7 @@
 # WebSocket Event Server
 
 The node exposes a lightweight WebSocket endpoint broadcasting block and transaction events.
-It starts automatically when `theminerzd` runs and binds to port `12345` by default.
+It starts automatically when `theminerzcoind` runs and binds to port `12345` by default.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- correct references to theminerz daemon

## Testing
- `grep -R "theminerzd" -n`
