### PR TITLE
Remove logs directory from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ src/qt/theminerzcoin-qt.creator.user
 src/qt/theminerzcoin-qt.files
 src/qt/theminerzcoin-qt.includes
 build/
+logs/

--- a/logs/auto_build_log.md
+++ b/logs/auto_build_log.md
@@ -1,5 +1,0 @@
-Log #1: Initial repo structure and dependencies logged.
-Log #2: Technologies identified.
-Step 3: Added clang-format, clang-tidy, rustfmt, ruff config.
-Step 5: depends build failed (missing permissions).
-Build and tests skipped due to missing deps.


### PR DESCRIPTION
## Summary
- ignore `logs/` directory
- delete `logs/auto_build_log.md`

## Testing
- `cmake -S . -B build` *(fails: could not find Qt5)*

