### PR TITLE
Fix docker build workflow checkout

### DIFF
--- a/.github/workflows/docker_build_push_master.yaml
+++ b/.github/workflows/docker_build_push_master.yaml
@@ -7,8 +7,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.7
-        with:
-          ref: add-jenkins
       - name: Set environment variables
         run: echo "GIT_CURRENT_BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Login to DockerHub Registry


### PR DESCRIPTION
## Summary
- fix checkout step in docker build workflow to use the triggering commit
- validate workflow YAML syntax

## Testing
- `python3 - <<'PY'
import yaml
yaml.safe_load(open('.github/workflows/docker_build_push_master.yaml'))
print('valid')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68684447b7f4832c9e614882520759cd