### PR TITLE
Add clang-format Google style with pre-commit config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-BasedOnStyle: LLVM
+BasedOnStyle: Google
 IndentWidth: 4
 ColumnLimit: 100
 DerivePointerAlignment: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.0
+    hooks:
+      - id: clang-format
+        files: '\.(cpp|h)$'


### PR DESCRIPTION
## Summary
- switch clang-format style to Google
- add pre-commit config using clang-format

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt5Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6868b3b9dbfc832c9fe108a3fbb41ee7