### PR TITLE
Enforce taproot element size

### DIFF
--- a/src/consensus/taproot.cpp
+++ b/src/consensus/taproot.cpp
@@ -10,12 +10,12 @@ bool VerifyTaprootSpend(const CTransaction& tx)
     if (tx.vin.empty() || tx.vout.empty()) return false;
 
     const CTxIn& in = tx.vin[0];
-    if (in.scriptSig.size() != 64) return false;
+    if (in.scriptSig.size() > MAX_TAPROOT_SCRIPT_ELEMENT_SIZE || in.scriptSig.size() != 64) return false;
     std::array<unsigned char,64> sig;
     std::copy(in.scriptSig.begin(), in.scriptSig.end(), sig.begin());
 
     const CScript& spk = tx.vout[0].scriptPubKey;
-    if (spk.size() != 34 || spk[0] != OP_1) return false;
+    if (spk.size() > MAX_TAPROOT_SCRIPT_ELEMENT_SIZE || spk.size() != 34 || spk[0] != OP_1) return false;
     unsigned char pk[32];
     memcpy(pk, &spk[1], 32);
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -282,7 +282,10 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
             //
             if (!script.GetOp(pc, opcode, vchPushValue))
                 return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
-            if (vchPushValue.size() > MAX_SCRIPT_ELEMENT_SIZE)
+            unsigned int push_limit = (flags & SCRIPT_VERIFY_TAPROOT) ?
+                                       MAX_TAPROOT_SCRIPT_ELEMENT_SIZE :
+                                       MAX_SCRIPT_ELEMENT_SIZE;
+            if (vchPushValue.size() > push_limit)
                 return set_error(serror, SCRIPT_ERR_PUSH_SIZE);
 
             // Note how OP_RESERVED does not count towards the opcode limit.

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -91,6 +91,9 @@ enum
     // See BIP112 for details
     SCRIPT_VERIFY_CHECKSEQUENCEVERIFY = (1U << 11),
 
+    // Enable segwit (BIP141) behavior
+    SCRIPT_VERIFY_WITNESS = (1U << 12),
+
     // Require the argument of OP_IF/NOTIF to be exactly 0x01 or empty vector
     //
     SCRIPT_VERIFY_MINIMALIF = (1U << 13),
@@ -98,6 +101,9 @@ enum
     // Signature(s) must be empty vector if an CHECK(MULTI)SIG operation failed
     //
     SCRIPT_VERIFY_NULLFAIL = (1U << 14),
+
+    // Enable tapscript validation rules
+    SCRIPT_VERIFY_TAPROOT = (1U << 15),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -20,6 +20,8 @@
 
 // Maximum number of bytes pushable to the stack
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520;
+// Maximum number of bytes pushable when executing tapscript
+static const unsigned int MAX_TAPROOT_SCRIPT_ELEMENT_SIZE = 10000;
 
 // Maximum number of non-push operations per script
 static const int MAX_OPS_PER_SCRIPT = 201;

--- a/src/test/taproot_tests.cpp
+++ b/src/test/taproot_tests.cpp
@@ -2,6 +2,8 @@
 #include "test/test_bitcoin.h"
 #include <wallet/wallet.h>
 #include <consensus/taproot.h>
+#include <script/interpreter.h>
+#include <script/script.h>
 
 BOOST_FIXTURE_TEST_SUITE(taproot_tests, BasicTestingSetup)
 
@@ -21,6 +23,24 @@ BOOST_AUTO_TEST_CASE(create_sign_verify)
     BOOST_CHECK(wallet.SignTransactionSchnorr(tx, key));
     CTransaction ctx(tx);
     BOOST_CHECK(Consensus::VerifyTaprootSpend(ctx));
+}
+
+BOOST_AUTO_TEST_CASE(taproot_element_size_limit)
+{
+    std::vector<unsigned char> data(MAX_TAPROOT_SCRIPT_ELEMENT_SIZE, 'x');
+    CScript script;
+    script << data;
+    std::vector<std::vector<unsigned char>> stack;
+    ScriptError err;
+    BOOST_CHECK(EvalScript(stack, script, SCRIPT_VERIFY_TAPROOT, BaseSignatureChecker(), &err));
+    BOOST_CHECK(err == SCRIPT_ERR_OK);
+
+    data.push_back('y');
+    script.clear();
+    script << data;
+    stack.clear();
+    BOOST_CHECK(!EvalScript(stack, script, SCRIPT_VERIFY_TAPROOT, BaseSignatureChecker(), &err));
+    BOOST_CHECK(err == SCRIPT_ERR_PUSH_SIZE);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- allow larger script elements for tapscript up to 10kB
- gate taproot and witness rules behind new flags
- test taproot element size acceptance/rejection

## Testing
- `./generate_build.sh` *(fails: Cannot find source file build/assembly.S)*
- `cmake --build build --target check` *(fails: No rule to make target 'check')*

