### PR TITLE
Update CI runners, Docker images, and add CodeQL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-14, windows-2025]
         sanitizer: [none, address, undefined]
     runs-on: ${{ matrix.os }}
     steps:
@@ -15,6 +15,35 @@ jobs:
         echo "CXXFLAGS=-fsanitize=${{ matrix.sanitizer }}" >> $GITHUB_ENV
         echo "LDFLAGS=-fsanitize=${{ matrix.sanitizer }}" >> $GITHUB_ENV
     - uses: actions/checkout@v3
+    - name: Install Clang 18
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-18 lld-18
+        echo "CC=clang-18" >> $GITHUB_ENV
+        echo "CXX=clang++-18" >> $GITHUB_ENV
+        echo "CFLAGS=$CFLAGS -flto -fprofile-generate" >> $GITHUB_ENV
+        echo "CXXFLAGS=$CXXFLAGS -flto -fprofile-generate" >> $GITHUB_ENV
+        echo "LDFLAGS=$LDFLAGS -flto" >> $GITHUB_ENV
+    - name: Install Clang 18 (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install llvm@18
+        echo "CC=$(brew --prefix llvm@18)/bin/clang" >> $GITHUB_ENV
+        echo "CXX=$(brew --prefix llvm@18)/bin/clang++" >> $GITHUB_ENV
+        echo "PATH=$(brew --prefix llvm@18)/bin:$PATH" >> $GITHUB_PATH
+        echo "CFLAGS=$CFLAGS -flto -fprofile-generate" >> $GITHUB_ENV
+        echo "CXXFLAGS=$CXXFLAGS -flto -fprofile-generate" >> $GITHUB_ENV
+        echo "LDFLAGS=$LDFLAGS -flto" >> $GITHUB_ENV
+    - name: Install Clang 18 (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        choco install llvm --version=18.1.0 -y
+        echo "CC=clang" >> $GITHUB_ENV
+        echo "CXX=clang++" >> $GITHUB_ENV
+        echo "CFLAGS=%CFLAGS% -flto -fprofile-generate" >> $GITHUB_ENV
+        echo "CXXFLAGS=%CXXFLAGS% -flto -fprofile-generate" >> $GITHUB_ENV
+        echo "LDFLAGS=%LDFLAGS% -flto" >> $GITHUB_ENV
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
@@ -32,17 +61,16 @@ jobs:
   fuzz:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-14, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: Configure fuzzers
       run: cmake -S . -B fuzz_build -DCMAKE_CXX_FLAGS="-fsanitize=fuzzer,address" -DCMAKE_C_FLAGS="-fsanitize=fuzzer,address"
     - name: Build fuzzers
-      run: cmake --build fuzz_build -j2 --target tx_deser_fuzz block_deser_fuzz script_interpreter_fuzz slashing_fuzz
+      run: cmake --build fuzz_build -j2
     - name: Run fuzzers
       run: |
-        ./fuzz_build/src/test/fuzz/tx_deser_fuzz -runs=1
-        ./fuzz_build/src/test/fuzz/block_deser_fuzz -runs=1
-        ./fuzz_build/src/test/fuzz/script_interpreter_fuzz -runs=1
-        ./fuzz_build/src/test/fuzz/slashing_fuzz -runs=1
+        for f in fuzz_build/src/test/fuzz/*_fuzz; do
+          "$f" -runs=1;
+        done

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,9 +16,14 @@ jobs:
   build:
     name: ${{ matrix.name }}
 
-    env:
+  env:
       MAKEJOBS: 4
       SDK_URL: https://bitcoincore.org/depends-sources/sdks
+      CC: clang-18
+      CXX: clang++-18
+      CFLAGS: -flto -fprofile-generate
+      CXXFLAGS: -flto -fprofile-generate
+      LDFLAGS: -flto
 
     strategy:
       fail-fast: false
@@ -33,7 +38,7 @@ jobs:
         include:
           - name: linux-32-bit
             host: i686-pc-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             packages: g++-multilib
             check-security: false
             check-symbols: false
@@ -43,7 +48,7 @@ jobs:
 
           - name: linux-64-bit
             host: x86_64-pc-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             packages: python3
             check-security: false
             check-symbols: false
@@ -54,7 +59,7 @@ jobs:
           - name: windows-64-bit
             host: x86_64-w64-mingw32
             arch: "i386"
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             packages: nsis g++-mingw-w64-x86-64 build-essential libtool pkg-config bsdmainutils curl git wine-binfmt wine64 wine32
             postinstall: |
               sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
@@ -68,7 +73,7 @@ jobs:
 
           - name: macos-64-bit
             host: x86_64-apple-darwin
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             packages: curl bsdmainutils cmake libz-dev python3-setuptools libtinfo5 xorriso
             check-security: false
             check-symbols: false
@@ -79,7 +84,7 @@ jobs:
 
           - name: linux-arm-32-bit
             host: arm-linux-gnueabihf
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             packages: g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
             check-security: false
             check-symbols: false
@@ -89,7 +94,7 @@ jobs:
 
           - name: linux-arm-64-bit
             host: aarch64-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             packages: g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
             check-security: false
             check-symbols: false
@@ -111,7 +116,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install make cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch bison
+          sudo apt-get install make cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch bison clang-18 lld-18
           sudo apt-get install ${{ matrix.packages }}
 
       - name: Post Install

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '**' ]
+permissions:
+  contents: read
+  security-events: write
+jobs:
+  analyze:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: cpp
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+  dependency-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4

--- a/.github/workflows/docker_build_push_master.yaml
+++ b/.github/workflows/docker_build_push_master.yaml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
   test:
     name: Build and Push Docker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.7

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:22.04 AS builder
+FROM ubuntu:24.04 AS builder
 RUN apt-get update && apt-get install -y build-essential cmake libssl-dev
 WORKDIR /build
 COPY . .
 RUN cmake -S . -B build && cmake --build build -j$(nproc)
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 COPY --from=builder /build/build/theminerzcoind /usr/local/bin/theminerzcoind
 ENTRYPOINT ["theminerzcoind"]


### PR DESCRIPTION
## Summary
- use ubuntu-24.04, macos-14 and windows-2025 runners
- build Docker image from Ubuntu 24.04
- install clang-18 with LTO/PGO flags
- run all fuzzers automatically
- add CodeQL scan and dependency review

## Testing
- `ruff check contrib/**/*.py qa/**/*.py *.py` *(fails: Failed to parse contrib/devtools/check-doc.py)*

------
https://chatgpt.com/codex/tasks/task_e_6868c8e79e98832c8c2f04ebf3ce77d2