### PR TITLE
Add Rust formatting to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,17 @@ repos:
     hooks:
       - id: clang-format
         files: '\.(cpp|h)$'
+
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        entry: rustfmt
+        language: system
+        types: [rust]
+      - id: cargo-fmt-check
+        name: cargo fmt --check
+        entry: cargo fmt --manifest-path rust/Cargo.toml -- --check
+        language: system
+        pass_filenames: false
+        files: '^rust/'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,19 @@ Please refer to the [Git manual](https://git-scm.com/doc) for more information a
   - Push changes to your fork
   - Create pull request
 
+Pre-commit Hooks
+----------------
+This repository uses [pre-commit](https://pre-commit.com/) to automatically
+format code. Install the hooks after cloning:
+
+```
+pip install pre-commit
+pre-commit install
+```
+
+Running the hooks will apply `clang-format` to C++ sources, `rustfmt` to Rust
+files, and execute `cargo fmt --check` for the crate in `rust/`.
+
 The title of the pull request should be prefixed by the component or area that the pull request affects. Examples:
 
     Consensus: Add new opcode for BIP-XXXX OP_CHECKAWESOMESIG

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,15 +1,21 @@
-use std::{env,fs,path::PathBuf};
+use std::{env, fs, path::PathBuf};
 
 fn main() {
     cxx_build::bridge("src/lib.rs").compile("theminerz_rust");
     println!("cargo:rerun-if-changed=src/lib.rs");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let header = out_dir.join("cxxbridge").join("include")
-        .join("theminerz_rust").join("src").join("lib.rs.h");
+    let header = out_dir
+        .join("cxxbridge")
+        .join("include")
+        .join("theminerz_rust")
+        .join("src")
+        .join("lib.rs.h");
     let dest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
-        .parent().unwrap()
-        .join("src").join("rust_bindings");
+        .parent()
+        .unwrap()
+        .join("src")
+        .join("rust_bindings");
     fs::create_dir_all(&dest).unwrap();
     fs::copy(header, dest.join("secp256k1.h")).unwrap();
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,5 @@
-use secp256k1::{Secp256k1, Message, PublicKey};
 use secp256k1::ecdsa::Signature;
+use secp256k1::{Message, PublicKey, Secp256k1};
 
 #[cxx::bridge]
 mod ffi {


### PR DESCRIPTION
## Summary
- apply Google-style clang-format rules
- add rustfmt and cargo fmt checks to pre-commit
- document pre-commit usage in CONTRIBUTING.md
- format existing Rust code to pass the new hooks

## Testing
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md rust/build.rs rust/src/lib.rs`


