### PR TITLE
Fix Boost download URL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ include(FetchContent)
 
 FetchContent_Declare(
   boost
-  URL https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.gz
+  URL https://downloads.sourceforge.net/project/boost/boost/1.85.0/boost_1_85_0.tar.gz
 )
 FetchContent_MakeAvailable(boost)
 


### PR DESCRIPTION
## Summary
- use SourceForge mirror to fetch Boost because JFrog returns an HTML page

## Testing
- `./generate_build.sh -DWITH_GUI=OFF` *(fails: install TARGETS given target "theminerzcoind" which does not exist)*
