### PR TITLE
Fix compilation errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,12 @@ list(REMOVE_ITEM CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/bitcoin-tx.cpp
 )
 add_library(core STATIC ${CORE_SOURCES})
-target_include_directories(core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(core PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/univalue/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/leveldb/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/leveldb/helpers/memenv
+)
 
 # Modules
 add_subdirectory(consensus)

--- a/src/compat.h
+++ b/src/compat.h
@@ -6,9 +6,7 @@
 #ifndef BITCOIN_COMPAT_H
 #define BITCOIN_COMPAT_H
 
-#if defined(HAVE_CONFIG_H)
 #include <config/bitcoin-config.h>
-#endif
 
 #ifdef WIN32
 #ifdef _WIN32_WINNT

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -75,15 +75,11 @@ struct Params {
     bool IsProtocolV3(int64_t nTime) const { return nTime > nProtocolV3Time && nTime != 1693994592; }
     bool IsProtocolV3_1(int64_t nTime) const { return nTime > nProtocolV3_1Time && nTime != 1713938400; }
 
-    unsigned int GetTargetSpacing(int nHeight) { return IsProtocolV2(nHeight) ? 300 : 300; }
-    int64_t GetDynamicTargetSpacing(int nHeight) const { return GetTargetSpacing(nHeight); }
-
     unsigned int GetDynamicTargetSpacing(int nHeight) const {
         int64_t spacing = nTargetSpacing;
         if (nHeight >= nBlockTimeReductionHeight) spacing /= 2;
         return spacing;
     }
-    main
     int nLastPOWBlock;
     int nForkheightRewardChange;
     int nStakeTimestampMask;

--- a/src/grpc/node.grpc.pb.h
+++ b/src/grpc/node.grpc.pb.h
@@ -4,7 +4,7 @@
 #ifndef GRPC_specs_2fnode_2eproto__INCLUDED
 #define GRPC_specs_2fnode_2eproto__INCLUDED
 
-#include "specs/node.pb.h"
+#include "node.pb.h"
 
 #include <functional>
 #include <grpcpp/generic/async_generic_service.h>

--- a/src/leveldb/benchmarks/db_bench_sqlite3.cc
+++ b/src/leveldb/benchmarks/db_bench_sqlite3.cc
@@ -5,6 +5,7 @@
 #include <sqlite3.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <ctime>
 
 #include "util/histogram.h"
 #include "util/random.h"

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -17,14 +17,14 @@
 template <typename T>
 struct secure_allocator : public std::allocator<T> {
     // MSVC8 default copy constructor is broken
-    typedef std::allocator<T> base;
-    typedef typename base::size_type size_type;
-    typedef typename base::difference_type difference_type;
-    typedef typename base::pointer pointer;
-    typedef typename base::const_pointer const_pointer;
-    typedef typename base::reference reference;
-    typedef typename base::const_reference const_reference;
-    typedef typename base::value_type value_type;
+    using base = std::allocator<T>;
+    using size_type = typename std::allocator_traits<base>::size_type;
+    using difference_type = typename std::allocator_traits<base>::difference_type;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
+    using value_type = T;
     secure_allocator() throw() {}
     secure_allocator(const secure_allocator& a) throw() : base(a) {}
     template <typename U>

--- a/src/support/allocators/zeroafterfree.h
+++ b/src/support/allocators/zeroafterfree.h
@@ -14,14 +14,14 @@
 template <typename T>
 struct zero_after_free_allocator : public std::allocator<T> {
     // MSVC8 default copy constructor is broken
-    typedef std::allocator<T> base;
-    typedef typename base::size_type size_type;
-    typedef typename base::difference_type difference_type;
-    typedef typename base::pointer pointer;
-    typedef typename base::const_pointer const_pointer;
-    typedef typename base::reference reference;
-    typedef typename base::const_reference const_reference;
-    typedef typename base::value_type value_type;
+    using base = std::allocator<T>;
+    using size_type = typename std::allocator_traits<base>::size_type;
+    using difference_type = typename std::allocator_traits<base>::difference_type;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
+    using value_type = T;
     zero_after_free_allocator() throw() {}
     zero_after_free_allocator(const zero_after_free_allocator& a) throw() : base(a) {}
     template <typename U>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -112,7 +112,7 @@ public:
 };
 
 /** Return a descriptor string for the given public key */
-std::string DescriptorForKey(const CPubKey& key) const;
+std::string DescriptorForKey(const CPubKey& key);
 
 /** Address book data */
 class CAddressBookData


### PR DESCRIPTION
## Summary
- include configuration header unconditionally
- clean up consensus parameters after merge conflict
- fix missing includes and modernize allocators
- install header search paths for univalue and leveldb
- correct descriptor helper signature and update grpc include
- add missing <ctime> include

## Testing
- `./generate_build.sh -DWITH_GUI=OFF`
- `./build.sh` *(fails: invalid ‘static_cast’ error in boost function)*

