### PR TITLE
Fix includes and version data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 3.18)
 project(TheMinerzCoin LANGUAGES C CXX)
+find_package(Boost REQUIRED COMPONENTS filesystem system)
 
 option(WITH_GUI "Build GUI" ON)
 option(WITH_RUST "Build Rust components" OFF)
 option(STRICT "Treat warnings as errors" OFF)
+option(WITH_GRPC "Build with gRPC support" OFF)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -21,6 +23,10 @@ endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 if(STRICT)
     add_compile_options(-Werror)
+endif()
+
+if(WITH_GRPC)
+    add_compile_definitions(WITH_GRPC)
 endif()
 
 include(FetchContent)

--- a/share/qt/Info.plist
+++ b/share/qt/Info.plist
@@ -17,7 +17,7 @@
   <string>APPL</string>
 
   <key>NSHumanReadableCopyright</key>
-  <string>3.0.0, Copyright © 2022-20224 The TheMinerzCoin developers</string>
+  <string>3.0.0, Copyright © 2022-2025 The TheMinerzCoin developers</string>
 
   <key>CFBundleShortVersionString</key>
   <string>3.0.0</string>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,10 @@ target_include_directories(core PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/univalue/include
     ${CMAKE_CURRENT_SOURCE_DIR}/leveldb/include
     ${CMAKE_CURRENT_SOURCE_DIR}/leveldb/helpers/memenv
+    ${CMAKE_CURRENT_SOURCE_DIR}/secp256k1/include
+    ${boost_SOURCE_DIR}
 )
+target_link_libraries(core PUBLIC Boost::filesystem Boost::system)
 
 # Modules
 add_subdirectory(consensus)
@@ -31,7 +34,9 @@ add_subdirectory(compat)
 add_subdirectory(bench)
 add_subdirectory(zmq)
 add_subdirectory(websockets)
-add_subdirectory(grpc)
+if(WITH_GRPC)
+    add_subdirectory(grpc)
+endif()
 if(WITH_GUI)
     add_subdirectory(qt)
 endif()
@@ -55,6 +60,9 @@ add_subdirectory(test)
 add_executable(theminerzcoind bitcoind.cpp)
 target_link_libraries(theminerzcoind PRIVATE
     core wallet consensus crypto policy primitives rpc script_lib node support
-    hw_wallet compat bench zmq_lib websockets grpc_services p2p neutrino
+    hw_wallet compat bench zmq_lib websockets p2p neutrino
     univalue secp256k1
 )
+if(WITH_GRPC)
+    target_link_libraries(theminerzcoind PRIVATE grpc_services)
+endif()

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -10,7 +10,7 @@
 
 #include <string>
 #include <map>
-#include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
 
 class CSubNet;
 class CAddrMan;

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -25,7 +25,7 @@
  * Copyright year (2009-this)
  * Todo: update this when changing our copyright comments in the source
  */
-#define COPYRIGHT_YEAR 2024
+#define COPYRIGHT_YEAR 2025
 
 #endif //HAVE_CONFIG_H
 

--- a/src/config/bitcoin-config.h
+++ b/src/config/bitcoin-config.h
@@ -12,16 +12,16 @@
 /* #undef CHAR_EQUALS_INT8 */
 
 /* Version Build */
-#define CLIENT_VERSION_BUILD 1
+#define CLIENT_VERSION_BUILD 0
 
 /* Version is release */
 #define CLIENT_VERSION_IS_RELEASE true
 
 /* Major version */
-#define CLIENT_VERSION_MAJOR 1
+#define CLIENT_VERSION_MAJOR 3
 
 /* Minor version */
-#define CLIENT_VERSION_MINOR 1
+#define CLIENT_VERSION_MINOR 0
 
 /* Copyright holder(s) before %s replacement */
 #define COPYRIGHT_HOLDERS "The %s developers"
@@ -33,7 +33,7 @@
 #define COPYRIGHT_HOLDERS_SUBSTITUTION "TheMinerzCoin"
 
 /* Copyright year */
-#define COPYRIGHT_YEAR 2023
+#define COPYRIGHT_YEAR 2025
 
 /* Define this symbol to build code that uses AVX2 intrinsics */
 #define ENABLE_AVX2 1

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -12,7 +12,7 @@
 #include "utilstrencodings.h"
 #include "version.h"
 
-#include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
 
 #include <leveldb/include/leveldb/db.h>
 #include <leveldb/include/leveldb/write_batch.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,7 +103,7 @@ FeeFilterRounder filterRounder(::minRelayTxFee);
 struct IteratorComparator
 {
     template<typename I>
-    bool operator()(const I& a, const I& b)
+    bool operator()(const I& a, const I& b) const
     {
         return &(*a) < &(*b);
     }

--- a/src/net.h
+++ b/src/net.h
@@ -26,7 +26,7 @@
 #include <arpa/inet.h>
 #endif
 
-#include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 #include <boost/signals2/signal.hpp>
 #include <array>

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -37,10 +37,10 @@ struct secure_allocator : public std::allocator<T> {
         typedef secure_allocator<_Other> other;
     };
 
-    T* allocate(std::size_t n, const void* hint = 0)
+    T* allocate(std::size_t n)
     {
         T* p;
-        p = std::allocator<T>::allocate(n, hint);
+        p = std::allocator<T>::allocate(n);
         if (p != NULL)
             LockedPageManager::Instance().LockRange(p, sizeof(T) * n);
         return p;

--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -12,7 +12,7 @@
 #include <cstdio>
 
 #include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
 

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -8,7 +8,7 @@
 #ifndef BITCOIN_TEST_TESTUTIL_H
 #define BITCOIN_TEST_TESTUTIL_H
 
-#include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
 
 boost::filesystem::path GetTempPath();
 

--- a/src/util.h
+++ b/src/util.h
@@ -25,7 +25,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/exceptions.hpp>
 

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
 
 #include <db_cxx.h>
 


### PR DESCRIPTION
## Summary
- set version to 3.0.0 and year 2025
- include Boost and secp256k1 headers properly
- add optional gRPC build flag and guard code
- replace deprecated boost filesystem includes
- fix iterator comparator constness

## Testing
- `./generate_build.sh -DWITH_GUI=OFF -DWITH_GRPC=OFF` *(passes)*
- `./build.sh -j1` *(fails: invalid function call in schnorr.cpp)*

