### PR TITLE
Fix build warnings and path handling

### DIFF
--- a/src/schnorr.cpp
+++ b/src/schnorr.cpp
@@ -15,7 +15,7 @@ secp256k1_context* GetContext()
         ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
         unsigned char seed[32];
         GetRandBytes(seed, 32);
-        secp256k1_context_randomize(ctx, seed);
+        (void)secp256k1_context_randomize(ctx, seed);
     }
     return ctx;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -521,7 +521,7 @@ void ClearDatadirCache()
 boost::filesystem::path GetConfigFile()
 {
     boost::filesystem::path pathConfigFile(GetArg("-conf", BITCOIN_CONF_FILENAME));
-    if (!pathConfigFile.is_complete())
+    if (!pathConfigFile.is_absolute())
         pathConfigFile = GetDataDir(false) / pathConfigFile;
 
     return pathConfigFile;
@@ -555,7 +555,7 @@ void ReadConfigFile(map<string, string>& mapSettingsRet,
 boost::filesystem::path GetPidFile()
 {
     boost::filesystem::path pathPidFile(GetArg("-pid", BITCOIN_PID_FILENAME));
-    if (!pathPidFile.is_complete()) pathPidFile = GetDataDir() / pathPidFile;
+    if (!pathPidFile.is_absolute()) pathPidFile = GetDataDir() / pathPidFile;
     return pathPidFile;
 }
 
@@ -816,7 +816,7 @@ std::string CopyrightHolders(const std::string& strPrefix)
     std::string strCopyrightHolders =
         strPrefix + "The Bitcoin Core developers" +
         "\n" + strPrefix + "The Blackcoin developers" +
-        "\n" + strPrefix + "The Blackcoin More developers";
+        "\n" + strPrefix + "The Blackcoin More developers" +
         "\n" + strPrefix + "TheMinerzCoin developers";
 
     return strCopyrightHolders;

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -11,6 +11,8 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
+#include <chrono>
+#include <thread>
 
 using namespace std;
 
@@ -56,20 +58,7 @@ int64_t GetLogTimeMicros()
 
 void MilliSleep(int64_t n)
 {
-
-/**
- * Boost's sleep_for was uninterruptable when backed by nanosleep from 1.50
- * until fixed in 1.52. Use the deprecated sleep method for the broken case.
- * See: https://svn.boost.org/trac/boost/ticket/7238
- */
-#if defined(HAVE_WORKING_BOOST_SLEEP_FOR)
-    boost::this_thread::sleep_for(boost::chrono::milliseconds(n));
-#elif defined(HAVE_WORKING_BOOST_SLEEP)
-    boost::this_thread::sleep(boost::posix_time::milliseconds(n));
-#else
-//should never get here
-#error missing boost sleep implementation
-#endif
+    std::this_thread::sleep_for(std::chrono::milliseconds(n));
 }
 
 std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5,20 +5,16 @@
 
 #include <config/bitcoin-config.h> // IWYU pragma: keep
 
-#include <validation.h>
 
 #include <arith_uint256.h>
 #include <chain.h>
 #include <checkqueue.h>
 #include <clientversion.h>
-#include <consensus/amount.h>
+#include <amount.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
-#include <consensus/tx_check.h>
-#include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <cuckoocache.h>
-#include <flatfile.h>
 #include <hash.h>
 #include <kernel/chain.h>
 #include <kernel/chainparams.h>


### PR DESCRIPTION
## Summary
- silence secp256k1_context_randomize return warning
- fix path checks for absolute paths
- correct copyright string
- use std::sleep_for for MilliSleep
- remove invalid includes in validation.cpp

## Testing
- `./generate_build.sh` *(fails: Could NOT find Boost)*
- `./generate_build.sh` *(pass after installing dependencies)*
- `./build.sh` *(fails: fatal error: kernel/chain.h: No such file or directory)*

