### PR TITLE
Fix Message deprecation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
 name = "theminerz_rust"
 version = "0.1.0"
 dependencies = [
+ "bitcoin_hashes",
  "cxx",
  "cxx-build",
  "secp256k1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["staticlib"]
 [dependencies]
 cxx = "1.0"
 secp256k1 = "0.31"
+bitcoin_hashes = "0.14"
 
 [build-dependencies]
 cxx-build = "1.0"


### PR DESCRIPTION
## Summary
- update secp256k1 usage to `Message::from_digest`
- compute SHA256 digest for ECDSA verification when needed
- depend on `bitcoin_hashes` crate

## Testing
- `cargo clippy --no-deps`
- `cargo test --no-run`


