### PR TITLE
Add MIT header to rust library and bindings

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -17,5 +17,19 @@ fn main() {
         .join("src")
         .join("rust_bindings");
     fs::create_dir_all(&dest).unwrap();
-    fs::copy(header, dest.join("secp256k1.h")).unwrap();
+    let dest_file = dest.join("secp256k1.h");
+    fs::copy(&header, &dest_file).unwrap();
+
+    const MIT_HEADER: &str = concat!(
+        "// Copyright (c) 2018-2022 The TheMinerzCoin developers\n",
+        "// Copyright (c) 2014-2018 The TheMinerzCoin Developers\n",
+        "// Copyright (c) 2013-2014 The NovaCoin Developers\n",
+        "// Copyright (c) 2011-2013 The PPCoin Developers\n",
+        "// Copyright (c) 2009-2016 The Bitcoin Core developers\n",
+        "// Distributed under the MIT software license, see the accompanying\n",
+        "// file COPYING or http://www.opensource.org/licenses/mit-license.php.\n\n",
+    );
+
+    let contents = fs::read_to_string(&dest_file).unwrap();
+    fs::write(&dest_file, format!("{}{}", MIT_HEADER, contents)).unwrap();
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2018-2022 The TheMinerzCoin developers
+// Copyright (c) 2014-2018 The TheMinerzCoin Developers
+// Copyright (c) 2013-2014 The NovaCoin Developers
+// Copyright (c) 2011-2013 The PPCoin Developers
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 use secp256k1::ecdsa::Signature;
 use secp256k1::{Message, PublicKey, Secp256k1};
 use bitcoin_hashes::{sha256, Hash};

--- a/src/rust_bindings/secp256k1.h
+++ b/src/rust_bindings/secp256k1.h
@@ -1,3 +1,11 @@
+// Copyright (c) 2018-2022 The TheMinerzCoin developers
+// Copyright (c) 2014-2018 The TheMinerzCoin Developers
+// Copyright (c) 2013-2014 The NovaCoin Developers
+// Copyright (c) 2011-2013 The PPCoin Developers
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 #include <array>
 #include <cassert>


### PR DESCRIPTION
## Summary
- add MIT copyright header to `rust/src/lib.rs`
- insert MIT header into generated `secp256k1.h`
- update build script to prepend the header automatically

## Testing
- `cargo build --release`
- `./generate_build.sh` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_686b965b7724832cb624b3f4eeceaad5