### PR TITLE
Enable compile_commands for clang tooling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 project(TheMinerzCoin LANGUAGES C CXX)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(Boost REQUIRED COMPONENTS filesystem system)
 
 option(WITH_GUI "Build GUI" ON)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,12 @@ pre-commit install
 Running the hooks will apply `clang-format` to C++ sources, `rustfmt` to Rust
 files, and execute `cargo fmt --check` for the crate in `rust/`.
 
+Compilation Database
+--------------------
+The CMake configuration writes a `compile_commands.json` file to the
+`build/` directory. Regenerate it whenever you change CMake options by
+rerunning `./generate_build.sh`.
+
 The title of the pull request should be prefixed by the component or area that the pull request affects. Examples:
 
     Consensus: Add new opcode for BIP-XXXX OP_CHECKAWESOMESIG


### PR DESCRIPTION
## Summary
- generate `compile_commands.json` by default with CMake
- document how to regenerate the file

## Testing
- `./generate_build.sh -DWITH_GUI=OFF`
- `clang-tidy -p build /workspace/TheMinerzCoin/src/compat/strnlen.cpp --quiet`

