### PR TITLE
Run ruff and tidy qa framework

### DIFF
--- a/qa/rpc-tests/test_framework/__init__.py
+++ b/qa/rpc-tests/test_framework/__init__.py
@@ -1,0 +1,1 @@
+"""Test framework utilities."""

--- a/qa/rpc-tests/test_framework/address.py
+++ b/qa/rpc-tests/test_framework/address.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
+"""Utilities for encoding and decoding Base58 addresses.
+
+This module provides helpers to work with Base58 P2PKH and P2SH addresses.
+"""
+
 # Copyright (c) 2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#
-# address.py
-#
-# This file encodes and decodes BASE58 P2PKH and P2SH addresses
-#
 
 from .script import CScript, hash160, hash256
 from .util import bytes_to_hex_str, hex_str_to_bytes
 
-chars = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+CHARS = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
 
 def byte_to_base58(b, version):
@@ -23,10 +23,10 @@ def byte_to_base58(b, version):
     str += checksum[:8]
     value = int("0x" + str, 0)
     while value > 0:
-        result = chars[value % 58] + result
+        result = CHARS[value % 58] + result
         value //= 58
     while str[:2] == "00":
-        result = chars[0] + result
+        result = CHARS[0] + result
         str = str[2:]
     return result
 
@@ -42,7 +42,7 @@ def base58_decode(s):
     value = 0
     for c in s:
         value *= 58
-        idx = chars.find(c)
+        idx = CHARS.find(c)
         assert idx != -1
         value += idx
 
@@ -51,7 +51,7 @@ def base58_decode(s):
         hex_str = "0" + hex_str
 
     for c in s:
-        if c == chars[0]:
+        if c == CHARS[0]:
             hex_str = "00" + hex_str
         else:
             break

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+"""Bitcoin P2P network "half-node" implementation used for testing."""
+
 # Copyright (c) 2010 ArtForz -- public domain half-a-node
 # Copyright (c) 2012 Jeff Garzik
 # Copyright (c) 2010-2016 The Bitcoin Core developers
@@ -22,21 +24,22 @@
 # ser_*, deser_*: functions that handle serialization/deserialization
 
 
-import struct
-import socket
 import asyncore
-import time
-import sys
-import random
-from .util import hex_str_to_bytes, bytes_to_hex_str
-from io import BytesIO
-from codecs import encode
-import hashlib
-from threading import RLock
-from threading import Thread
-import logging
 import copy
+import hashlib
+import logging
+import random
+import socket
+import struct
+import sys
+import time
+from codecs import encode
+from io import BytesIO
+from threading import RLock, Thread
+
 from test_framework.siphash import siphash256
+
+from .util import bytes_to_hex_str, hex_str_to_bytes
 
 BIP0031_VERSION = 60000
 MY_VERSION = 70014  # past bip-31 for ping/pong
@@ -203,12 +206,12 @@ def ser_int_vector(l):
     return r
 
 # Deserialize from a hex string representation (eg from RPC)
-def FromHex(obj, hex_string):
+def from_hex(obj, hex_string):
     obj.deserialize(BytesIO(hex_str_to_bytes(hex_string)))
     return obj
 
 # Convert a binary-serializable object to hex (eg for submission via RPC)
-def ToHex(obj):
+def to_hex(obj):
     return bytes_to_hex_str(obj.serialize())
 
 # Objects that map to bitcoind objects, which can be serialized/deserialized

--- a/qa/rpc-tests/test_framework/netutil.py
+++ b/qa/rpc-tests/test_framework/netutil.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
+"""Linux network utility helpers."""
+
 # Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 # Linux network utilities
 
-import sys
-import socket
-import fcntl
-import struct
 import array
+import fcntl
 import os
-from binascii import unhexlify, hexlify
+import socket
+import struct
+import sys
+from binascii import hexlify, unhexlify
 
 # Roughly based on http://voorloopnul.com/blog/a-python-netstat-in-less-than-100-lines-of-code/ by Ricardo Pascal
 STATE_ESTABLISHED = '01'

--- a/qa/rpc-tests/test_framework/siphash.py
+++ b/qa/rpc-tests/test_framework/siphash.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+"""Specialized SipHash-2-4 implementations used in tests."""
+
 # Copyright (c) 2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.


### PR DESCRIPTION
## Summary
- run `ruff --fix` over qa test framework
- silence pylint module docstring warnings
- convert a few variables to snake_case

## Testing
- `ruff check qa/rpc-tests/test_framework/address.py`
- `ruff check qa/rpc-tests/test_framework/blockstore.py | head -n 20`


