### PR TITLE
Add MIT headers to websocket and lightning modules

### DIFF
--- a/src/lightning/lightning_client.cpp
+++ b/src/lightning/lightning_client.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2025 The TheMinerzCoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "lightning_client.h"
 
 #ifdef ENABLE_LIGHTNING

--- a/src/lightning/lightning_client.h
+++ b/src/lightning/lightning_client.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2025 The TheMinerzCoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <memory>

--- a/src/websockets/events.cpp
+++ b/src/websockets/events.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2025 The TheMinerzCoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "validationinterface.h"
 #include <libwebsockets.h>
 #include <list>

--- a/src/websockets/events.h
+++ b/src/websockets/events.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2022-2025 The TheMinerzCoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 bool StartWebSocketServer(unsigned short port);


### PR DESCRIPTION
## Summary
- insert standard MIT license header in websocket files
- add MIT license header in lightning client module

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_686c251df8f8832cac6cfaa6f87f84f7