### PR TITLE
Update rpcuser script for Python 3

### DIFF
--- a/share/rpcuser/rpcuser.py
+++ b/share/rpcuser/rpcuser.py
@@ -1,41 +1,37 @@
-#!/usr/bin/env python2 
-# Copyright (c) 2015 The Bitcoin Core developers 
-# Distributed under the MIT software license, see the accompanying 
+#!/usr/bin/env python3
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-import hashlib
-import sys
-import os
-from random import SystemRandom
 import base64
+import hashlib
 import hmac
+import os
+import sys
+from random import SystemRandom
 
 if len(sys.argv) < 2:
-    sys.stderr.write('Please include username as an argument.\n')
+    sys.stderr.write("Please include username as an argument.\n")
     sys.exit(0)
 
 username = sys.argv[1]
 
-#This uses os.urandom() underneath
+# This uses os.urandom() underneath
 cryptogen = SystemRandom()
 
-#Create 16 byte hex salt
+# Create 16 byte hex salt
 salt_sequence = [cryptogen.randrange(256) for i in range(16)]
 hexseq = list(map(hex, salt_sequence))
 salt = "".join([x[2:] for x in hexseq])
 
-#Create 32 byte b64 password
-password = base64.urlsafe_b64encode(os.urandom(32))
+# Create 32 byte b64 password
+password = base64.urlsafe_b64encode(os.urandom(32)).decode("utf-8")
 
 digestmod = hashlib.sha256
 
-if sys.version_info.major >= 3:
-    password = password.decode('utf-8')
-    digestmod = 'SHA256'
- 
-m = hmac.new(bytearray(salt, 'utf-8'), bytearray(password, 'utf-8'), digestmod)
+m = hmac.new(bytearray(salt, "utf-8"), bytearray(password, "utf-8"), digestmod)
 result = m.hexdigest()
 
 print("String to be appended to theminerzcoin.conf:")
-print("rpcauth="+username+":"+salt+"$"+result)
-print("Your password:\n"+password)
+print("rpcauth=" + username + ":" + salt + "$" + result)
+print("Your password:\n" + password)


### PR DESCRIPTION
## Summary
- update `rpcuser.py` to use `python3` shebang
- drop Python 2 compatibility code
- clean up imports and format file with `black`

## Testing
- `ruff check share/rpcuser/rpcuser.py`
- `python3 -m py_compile share/rpcuser/rpcuser.py`

