### PR TITLE
Use snprintf for safer formatting

### DIFF
--- a/src/secp256k1/src/bench_ecmult.c
+++ b/src/secp256k1/src/bench_ecmult.c
@@ -127,7 +127,7 @@ static void run_test(bench_data* data, size_t count, int includes_g, int num_ite
     }
 
     /* Run the benchmark. */
-    sprintf(str, includes_g ? "ecmult_%ig" : "ecmult_%i", (int)count);
+    snprintf(str, sizeof(str), includes_g ? "ecmult_%ig" : "ecmult_%i", (int)count);
     run_benchmark(str, bench_ecmult, bench_ecmult_setup, bench_ecmult_teardown, data, 10, count * iters);
 }
 

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<10; ++x) {
         for (int y = 0; y < 10; y++) {
-            sprintf(buf, "%d", x);
+            snprintf(buf, sizeof(buf), "%d", x);
             StringContentsSerializer key(buf);
             for (int z = 0; z < y; z++)
                 key += key;
@@ -297,12 +297,12 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
             seek_start = 0;
         else
             seek_start = 5;
-        sprintf(buf, "%d", seek_start);
+        snprintf(buf, sizeof(buf), "%d", seek_start);
         StringContentsSerializer seek_key(buf);
         it->Seek(seek_key);
         for (int x=seek_start; x<10; ++x) {
             for (int y = 0; y < 10; y++) {
-                sprintf(buf, "%d", x);
+                snprintf(buf, sizeof(buf), "%d", x);
                 string exp_key(buf);
                 for (int z = 0; z < y; z++)
                     exp_key += exp_key;

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -22,7 +22,7 @@ std::string base_blob<BITS>::GetHex() const
 {
     char psz[sizeof(data) * 2 + 1];
     for (unsigned int i = 0; i < sizeof(data); i++)
-        sprintf(psz + i * 2, "%02x", data[sizeof(data) - i - 1]);
+        snprintf(psz + i * 2, sizeof(psz) - i * 2, "%02x", data[sizeof(data) - i - 1]);
     return std::string(psz, psz + sizeof(data) * 2);
 }
 


### PR DESCRIPTION
## Summary
- replace deprecated `sprintf` with `snprintf` in `uint256.cpp`
- use `snprintf` in dbwrapper unit tests
- apply `snprintf` to secp256k1 benchmark

## Testing
- `./generate_build.sh -DWITH_GUI=OFF -DWITH_RUST=OFF` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_686c9f0f901c832c9705a2fea2cf4ba4