### PR TITLE
Update workflow runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2025]
+        os: [ubuntu-22.04, macos-13, windows-2022]
         sanitizer: [none, address, undefined]
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +61,7 @@ jobs:
   fuzz:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2025]
+        os: [ubuntu-22.04, macos-13, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -38,7 +38,7 @@ jobs:
         include:
           - name: linux-32-bit
             host: i686-pc-linux-gnu
-            os: ubuntu-24.04
+            os: ubuntu-22.04
             packages: g++-multilib
             check-security: false
             check-symbols: false
@@ -48,7 +48,7 @@ jobs:
 
           - name: linux-64-bit
             host: x86_64-pc-linux-gnu
-            os: ubuntu-24.04
+            os: ubuntu-22.04
             packages: python3
             check-security: false
             check-symbols: false
@@ -59,7 +59,7 @@ jobs:
           - name: windows-64-bit
             host: x86_64-w64-mingw32
             arch: "i386"
-            os: ubuntu-24.04
+            os: ubuntu-22.04
             packages: nsis g++-mingw-w64-x86-64 build-essential libtool pkg-config bsdmainutils curl git wine-binfmt wine64 wine32
             postinstall: |
               sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
@@ -73,7 +73,7 @@ jobs:
 
           - name: macos-64-bit
             host: x86_64-apple-darwin
-            os: ubuntu-24.04
+            os: ubuntu-22.04
             packages: curl bsdmainutils cmake libz-dev python3-setuptools libtinfo5 xorriso
             check-security: false
             check-symbols: false
@@ -84,7 +84,7 @@ jobs:
 
           - name: linux-arm-32-bit
             host: arm-linux-gnueabihf
-            os: ubuntu-24.04
+            os: ubuntu-22.04
             packages: g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
             check-security: false
             check-symbols: false
@@ -94,7 +94,7 @@ jobs:
 
           - name: linux-arm-64-bit
             host: aarch64-linux-gnu
-            os: ubuntu-24.04
+            os: ubuntu-22.04
             packages: g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
             check-security: false
             check-symbols: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2022, macos-14]
+        os: [ubuntu-22.04, windows-2022, macos-13]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ permissions:
   security-events: write
 jobs:
   analyze:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,7 +22,7 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
   dependency-review:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Dependency review

--- a/.github/workflows/docker_build_push_master.yaml
+++ b/.github/workflows/docker_build_push_master.yaml
@@ -3,10 +3,10 @@ on: [push]
 jobs:
   test:
     name: Build and Push Docker
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4
       - name: Set environment variables
         run: echo "GIT_CURRENT_BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Login to DockerHub Registry


### PR DESCRIPTION
## Summary
- update GitHub Action runners to supported versions
- enforce checkout at `actions/checkout@v4`

## Testing
- `pre-commit run --files .github/workflows/build.yml .github/workflows/c-cpp.yml .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/docker_build_push_master.yaml` *(fails: command not found)*

