### PR TITLE
Implement CScript.join

### DIFF
--- a/qa/rpc-tests/test_framework/script.py
+++ b/qa/rpc-tests/test_framework/script.py
@@ -687,8 +687,17 @@ class CScript(bytes):
             raise TypeError('Can not add a %r instance to a CScript' % other.__class__)
 
     def join(self, iterable):
-        # join makes no sense for a CScript()
-        raise NotImplementedError
+        """Return a new ``CScript`` joining ``iterable`` with ``self`` as
+        delimiter.
+
+        ``iterable`` elements are first coerced via ``__coerce_instance`` so
+        that integers or ``CScriptOp`` objects can be joined directly.  The
+        behaviour mirrors ``bytes.join`` but preserves the ``CScript``
+        subclass."""
+
+        coerced = [self.__coerce_instance(elem) for elem in iterable]
+        joined = bytes(self).join(coerced)
+        return CScript(joined)
 
     def __new__(cls, value=b''):
         if isinstance(value, bytes) or isinstance(value, bytearray):

--- a/tests/test_cscript_join.py
+++ b/tests/test_cscript_join.py
@@ -1,0 +1,35 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# Load the script module as part of a pseudo package so relative imports work
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "qa"
+    / "rpc-tests"
+    / "test_framework"
+    / "script.py"
+)
+
+# Expose a minimal "test_framework" package so relative imports succeed
+pkg = types.ModuleType("test_framework")
+pkg.__path__ = [str(SCRIPT_PATH.parent)]
+sys.modules["test_framework"] = pkg
+spec = importlib.util.spec_from_file_location("test_framework.script", SCRIPT_PATH)
+script = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(script)
+CScript = script.CScript
+
+
+def test_cscript_join_returns_cscript():
+    delim = CScript([b" "])
+    parts = [CScript([b"a"]), CScript([b"b"]), CScript([b"c"])]
+    result = delim.join(parts)
+    assert isinstance(result, CScript)
+
+    coerced = [CScript._CScript__coerce_instance(p) for p in parts]
+    expected_bytes = bytes(delim).join(coerced)
+    assert result == CScript(expected_bytes)
+
+


### PR DESCRIPTION
## Summary
- implement previously unimplemented `CScript.join` in the qa framework
- add unit test for the new helper

## Testing
- `pytest tests/test_cscript_join.py -q`
- `cargo test --manifest-path rust/Cargo.toml --all --quiet`
- `cmake -B build` *(fails: Could NOT find Boost)*
- `npm test` *(fails: package.json missing)*

