### PR TITLE
Improve build scripts and rename IPv6 helper

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
-set -e
+# Simple wrapper to invoke the CMake build from project root.
+set -euo pipefail
+
 cmake --build build "$@"

--- a/generate_build.sh
+++ b/generate_build.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
-set -e
+# Generate a CMake build directory.
+set -euo pipefail
+
 cmake -S . -B build -DCRC32C_USE_GLOG=OFF "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
-set -e
+# Install build artifacts from the CMake build directory.
+set -euo pipefail
+
 cmake --install build "$@"

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -8,7 +8,7 @@ import socket
 from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from test_framework.netutil import test_ipv6_local
+from test_framework.netutil import check_ipv6_local
 '''
 Test plan:
 - Start bitcoind's with different proxy configurations
@@ -40,7 +40,7 @@ class ProxyTest(BitcoinTestFramework):
         self.num_nodes = 4
         self.setup_clean_chain = False
 
-        self.have_ipv6 = test_ipv6_local()
+        self.have_ipv6 = check_ipv6_local()
         # Create two proxies on different ports
         # ... one unauthenticated
         self.conf1 = Socks5Configuration()

--- a/qa/rpc-tests/test_framework/netutil.py
+++ b/qa/rpc-tests/test_framework/netutil.py
@@ -141,10 +141,8 @@ def addr_to_hex(addr):
         raise ValueError('Could not parse address %s' % addr)
     return hexlify(bytearray(addr)).decode('ascii')
 
-def test_ipv6_local():
-    '''
-    Check for (local) IPv6 support.
-    '''
+def check_ipv6_local() -> bool:
+    """Return ``True`` if IPv6 localhost is reachable."""
     import socket
     # By using SOCK_DGRAM this will not actually make a connection, but it will
     # fail if there is no route to IPv6 localhost.


### PR DESCRIPTION
## Summary
- harden shell helper scripts with `set -euo pipefail`
- add short comments to helper scripts
- rename `test_ipv6_local` to `check_ipv6_local`
- update imports in `proxy_test.py`

## Testing
- `pytest -q`
- `flake8` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_686e1e1e16fc832ca2af95b0f5502f1b