### PR TITLE
Fix devtools Python 3 lint issues

### DIFF
--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -10,8 +10,8 @@ Return value is 0 to indicate no error.
 Author: @MarcoFalke
 '''
 
-from subprocess import check_output
 import re
+from subprocess import check_output
 
 FOLDER_GREP = 'src'
 FOLDER_TEST = 'src/test/'

--- a/contrib/devtools/circular-dependencies.py
+++ b/contrib/devtools/circular-dependencies.py
@@ -3,8 +3,8 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-import sys
 import re
+import sys
 from typing import Dict, List, Set
 
 MAPPING = {

--- a/contrib/devtools/clang-format-diff.py
+++ b/contrib/devtools/clang-format-diff.py
@@ -74,7 +74,6 @@ import re
 import subprocess
 import sys
 
-
 # Change this to the full path if clang-format is not on the path.
 binary = 'clang-format'
 

--- a/contrib/devtools/clang-format.py
+++ b/contrib/devtools/clang-format.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Wrapper script for clang-format
 
@@ -9,35 +9,31 @@ file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
 
 import os
-import sys
 import subprocess
+import sys
 
 tested_versions = ['3.6.0', '3.6.1', '3.6.2'] # A set of versions known to produce the same output
 accepted_file_extensions = ('.h', '.cpp') # Files to format
 
 def check_clang_format_version(clang_format_exe):
     try:
-        output = subprocess.check_output([clang_format_exe, '-version'])
+        output = subprocess.check_output([clang_format_exe, '-version']).decode()
         for ver in tested_versions:
             if ver in output:
-                print "Detected clang-format version " + ver
+                print("Detected clang-format version " + ver)
                 return
         raise RuntimeError("Untested version: " + output)
     except Exception as e:
-        print 'Could not verify version of ' + clang_format_exe + '.'
+        print('Could not verify version of ' + clang_format_exe + '.')
         raise e
 
 def check_command_line_args(argv):
     required_args = ['{clang-format-exe}', '{files}']
     example_args = ['clang-format-3.x', 'src/main.cpp', 'src/wallet/*']
 
-    if(len(argv) < len(required_args) + 1):
-        for word in (['Usage:', argv[0]] + required_args):
-            print word,
-        print ''
-        for word in (['E.g:', argv[0]] + example_args):
-            print word,
-        print ''
+    if len(argv) < len(required_args) + 1:
+        print(' '.join(['Usage:', argv[0]] + required_args))
+        print(' '.join(['E.g:', argv[0]] + example_args))
         sys.exit(1)
 
 def run_clang_format(clang_format_exe, files):
@@ -46,10 +42,10 @@ def run_clang_format(clang_format_exe, files):
             for path, dirs, files in os.walk(target):
                 run_clang_format(clang_format_exe, (os.path.join(path, f) for f in files))
         elif target.endswith(accepted_file_extensions):
-            print "Format " + target
+            print("Format " + target)
             subprocess.check_call([clang_format_exe, '-i', '-style=file', target], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
         else:
-            print "Skip " + target
+            print("Skip " + target)
 
 def main(argv):
     check_command_line_args(argv)

--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -3,12 +3,12 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-import re
-import fnmatch
-import sys
-import subprocess
 import datetime
+import fnmatch
 import os
+import re
+import subprocess
+import sys
 
 ################################################################################
 # file filtering

--- a/contrib/devtools/fix-copyright-headers.py
+++ b/contrib/devtools/fix-copyright-headers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Run this script to update all the copyright headers of files
 that were changed this year.
@@ -12,8 +12,8 @@ it will change it to
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 '''
 import os
-import time
 import re
+import time
 
 year = time.gmtime()[0]
 CMD_GIT_DATE = 'git log --format=%%ad --date=short -1 %s | cut -d"-" -f 1'
@@ -26,9 +26,9 @@ EXTENSIONS = [".cpp",".h", ".py"]
 
 def get_git_date(file_path):
   r = os.popen(CMD_GIT_DATE % file_path)
-  for l in r:
+  for line in r:
     # Result is one line, so just return
-    return l.replace("\n","")
+    return line.replace("\n", "")
   return ""
 
 n=1
@@ -41,6 +41,6 @@ for folder in FOLDERS:
         if str(year) == git_date:
           # Only update if current year is not found
           if REGEX_CURRENT.search(open(file_path, "r").read()) is None:
-            print n,"Last git edit", git_date, "-", file_path
-            os.popen(CMD_REGEX % (year,file_path))
+            print(n, "Last git edit", git_date, "-", file_path)
+            os.popen(CMD_REGEX % (year, file_path))
             n = n + 1

--- a/contrib/devtools/optimize-pngs.py
+++ b/contrib/devtools/optimize-pngs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -6,11 +6,13 @@
 Run this script every time you change one of the png files. Using pngcrush, it will optimize the png files, remove various color profiles, remove ancillary chunks (alla) and text chunks (text).
 #pngcrush -brute -ow -rem gAMA -rem cHRM -rem iCCP -rem sRGB -rem alla -rem text
 '''
-import os
-import sys
-import subprocess
 import hashlib
+import os
+import subprocess
+import sys
+
 from PIL import Image
+
 
 def file_hash(filename):
     '''Return hash of raw file contents'''
@@ -33,46 +35,94 @@ noHashChange = True
 
 outputArray = []
 for folder in folders:
-    absFolder=os.path.join(basePath, folder)
+    absFolder = os.path.join(basePath, folder)
     for file in os.listdir(absFolder):
         extension = os.path.splitext(file)[1]
         if extension.lower() == '.png':
-            print("optimizing "+file+"..."),
+            print("optimizing " + file + "...", end='')
             file_path = os.path.join(absFolder, file)
-            fileMetaMap = {'file' : file, 'osize': os.path.getsize(file_path), 'sha256Old' : file_hash(file_path)};
+            fileMetaMap = {
+                'file': file,
+                'osize': os.path.getsize(file_path),
+                'sha256Old': file_hash(file_path),
+            }
             fileMetaMap['contentHashPre'] = content_hash(file_path)
         
             pngCrushOutput = ""
             try:
                 pngCrushOutput = subprocess.check_output(
-                        [pngcrush, "-brute", "-ow", "-rem", "gAMA", "-rem", "cHRM", "-rem", "iCCP", "-rem", "sRGB", "-rem", "alla", "-rem", "text", file_path],
-                        stderr=subprocess.STDOUT).rstrip('\n')
-            except:
-                print "pngcrush is not installed, aborting..."
+                    [
+                        pngcrush,
+                        "-brute",
+                        "-ow",
+                        "-rem",
+                        "gAMA",
+                        "-rem",
+                        "cHRM",
+                        "-rem",
+                        "iCCP",
+                        "-rem",
+                        "sRGB",
+                        "-rem",
+                        "alla",
+                        "-rem",
+                        "text",
+                        file_path,
+                    ],
+                    stderr=subprocess.STDOUT,
+                ).rstrip("\n")
+            except Exception:
+                print("pngcrush is not installed, aborting...")
                 sys.exit(0)
         
             #verify
-            if "Not a PNG file" in subprocess.check_output([pngcrush, "-n", "-v", file_path], stderr=subprocess.STDOUT):
-                print "PNG file "+file+" is corrupted after crushing, check out pngcursh version"
+            if "Not a PNG file" in subprocess.check_output([
+                pngcrush,
+                "-n",
+                "-v",
+                file_path,
+            ], stderr=subprocess.STDOUT):
+                print("PNG file " + file + " is corrupted after crushing, check out pngcursh version")
                 sys.exit(1)
             
             fileMetaMap['sha256New'] = file_hash(file_path)
             fileMetaMap['contentHashPost'] = content_hash(file_path)
 
             if fileMetaMap['contentHashPre'] != fileMetaMap['contentHashPost']:
-                print "Image contents of PNG file "+file+" before and after crushing don't match"
+                print(
+                    "Image contents of PNG file "
+                    + file
+                    + " before and after crushing don't match"
+                )
                 sys.exit(1)
 
             fileMetaMap['psize'] = os.path.getsize(file_path)
             outputArray.append(fileMetaMap)
-            print("done\n"),
+            print("done\n")
 
-print "summary:\n+++++++++++++++++"
+print("summary:\n+++++++++++++++++")
 for fileDict in outputArray:
     oldHash = fileDict['sha256Old']
     newHash = fileDict['sha256New']
     totalSaveBytes += fileDict['osize'] - fileDict['psize']
     noHashChange = noHashChange and (oldHash == newHash)
-    print fileDict['file']+"\n  size diff from: "+str(fileDict['osize'])+" to: "+str(fileDict['psize'])+"\n  old sha256: "+oldHash+"\n  new sha256: "+newHash+"\n"
+    print(
+        fileDict['file']
+        + "\n  size diff from: "
+        + str(fileDict['osize'])
+        + " to: "
+        + str(fileDict['psize'])
+        + "\n  old sha256: "
+        + oldHash
+        + "\n  new sha256: "
+        + newHash
+        + "\n"
+    )
     
-print "completed. Checksum stable: "+str(noHashChange)+". Total reduction: "+str(totalSaveBytes)+" bytes"
+print(
+    "completed. Checksum stable: "
+    + str(noHashChange)
+    + ". Total reduction: "
+    + str(totalSaveBytes)
+    + " bytes"
+)

--- a/contrib/devtools/pixie.py
+++ b/contrib/devtools/pixie.py
@@ -7,7 +7,7 @@ Compact, self-contained ELF implementation for bitcoin-core security checks.
 '''
 import struct
 import types
-from typing import Dict, List, Optional, Union, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 # you can find all these values in elf.h
 EI_NIDENT = 16

--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -13,6 +13,7 @@ from typing import List, Optional
 import lief
 import pixie
 
+
 def check_ELF_PIE(executable) -> bool:
     '''
     Check for position independent executable (PIE), allowing for address space randomization.

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -16,7 +16,6 @@ from typing import List, Optional
 
 import lief
 import pixie
-
 from utils import determine_wellknown_cmd
 
 # Debian 8 (Jessie) EOL: 2020. https://wiki.debian.org/DebianReleases#Production_Releases
@@ -160,7 +159,7 @@ def check_version(max_versions, version, arch) -> bool:
         lib = version
         ver = '0'
     ver = tuple([int(x) for x in ver.split('.')])
-    if not lib in max_versions:
+    if lib not in max_versions:
         return False
     if isinstance(max_versions[lib], tuple):
         return ver <= max_versions[lib]

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -11,6 +11,7 @@ import unittest
 
 from utils import determine_wellknown_cmd
 
+
 def write_testcode(filename):
     with open(filename, 'w', encoding="utf8") as f:
         f.write('''

--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -7,10 +7,11 @@ Test script for symbol-check.py
 '''
 import os
 import subprocess
-from typing import List
 import unittest
+from typing import List
 
 from utils import determine_wellknown_cmd
+
 
 def call_symbol_check(cc: List[str], source, executable, options):
     subprocess.run([*cc,source,'-o',executable] + options, check=True)

--- a/contrib/devtools/update-translations.py
+++ b/contrib/devtools/update-translations.py
@@ -16,11 +16,12 @@ TODO:
 - auto-add new translations to the build system according to the translation process
 '''
 from __future__ import division, print_function
-import subprocess
-import re
-import sys
-import os
+
 import io
+import os
+import re
+import subprocess
+import sys
 import xml.etree.ElementTree as ET
 
 # Name of transifex tool

--- a/contrib/devtools/utils.py
+++ b/contrib/devtools/utils.py
@@ -5,9 +5,9 @@
 '''
 Common utility functions
 '''
+import os
 import shutil
 import sys
-import os
 from typing import List
 
 


### PR DESCRIPTION
## Summary
- run `ruff` on contrib devtools
- sort imports and modernise Python syntax
- update `clang-format.py` and other utilities for Python 3

## Testing
- `ruff check contrib/devtools`
- `python3 contrib/devtools/clang-format.py --help`
