### PR TITLE
Fix IPv6 socket closure

### DIFF
--- a/qa/rpc-tests/test_framework/netutil.py
+++ b/qa/rpc-tests/test_framework/netutil.py
@@ -148,8 +148,8 @@ def check_ipv6_local() -> bool:
     # fail if there is no route to IPv6 localhost.
     have_ipv6 = True
     try:
-        s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-        s.connect(('::1', 0))
+        with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as s:
+            s.connect(('::1', 0))
     except socket.error:
         have_ipv6 = False
     return have_ipv6


### PR DESCRIPTION
## Summary
- prevent a resource leak in `check_ipv6_local`

## Testing
- `python3 qa/rpc-tests/proxy_test.py --srcdir=src` *(fails: FileNotFoundError for theminerzcoind)*

