### PR TITLE
Add pyzmq dependency and skip ZMQ tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ There are also [regression and integration tests](/qa) of the RPC interface, wri
 in Python, that are run automatically on the build server.
 These tests can be run (if the [test dependencies](/qa) are installed) with: `qa/pull-tester/rpc-tests.py`
 
+The ZMQ-based tests additionally require the `pyzmq` Python package.
+
 GitHub Actions build every pull request on Linux, macOS and Windows and run the unit and sanity tests automatically. The workflow can be executed locally using [act](https://github.com/nektos/act) with `act -j build`.
 
 ### Manual Quality Assurance (QA) Testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,9 @@ line-length = 88
 [tool.ruff.lint]
 select = ["E", "F", "I"]
 ignore = ["E501"]
+
+[project]
+dependencies = [
+    "pyzmq"
+]
+

--- a/qa/rpc-tests/zmq_test.py
+++ b/qa/rpc-tests/zmq_test.py
@@ -9,6 +9,8 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
+import pytest
+pytest.importorskip("zmq")
 import zmq
 import struct
 


### PR DESCRIPTION
## Summary
- add pyzmq to project dependencies
- skip ZMQ tests when pyzmq isn't installed
- document pyzmq requirement for ZMQ tests in README

## Testing
- `pytest -v`

