### PR TITLE
Add strict shell mode and headers

### DIFF
--- a/contrib/devtools/gen-manpages.sh
+++ b/contrib/devtools/gen-manpages.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+# Generate manual pages for TheMinerzCoin binaries.
 # Copyright (c) 2016-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/contrib/devtools/git-subtree-check.sh
+++ b/contrib/devtools/git-subtree-check.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -euo pipefail
+# Check that a subtree merge exists for a given directory and commit.
 # Copyright (c) 2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/contrib/devtools/split-debug.sh
+++ b/contrib/devtools/split-debug.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-set -e
+set -euo pipefail
+# Split debugging symbols from a binary.
 if [ $# -ne 3 ];
     then echo "usage: $0 <input> <stripped-binary> <debug-binary>"
 fi

--- a/contrib/devtools/test_deterministic_coverage.sh
+++ b/contrib/devtools/test_deterministic_coverage.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
+# Test for deterministic coverage across unit test runs.
 #
 # Copyright (c) 2019-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
-# Test for deterministic coverage across unit test runs.
 
 export LC_ALL=C
 

--- a/contrib/devtools/utxo_snapshot.sh
+++ b/contrib/devtools/utxo_snapshot.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
+# Create or verify a UTXO snapshot using bitcoin-cli.
 #
 # Copyright (c) 2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
-export LC_ALL=C
 
-set -ueo pipefail
+export LC_ALL=C
 
 if (( $# < 3 )); then
   echo 'Usage: utxo_snapshot.sh <generate-at-height> <snapshot-out-path> <bitcoin-cli-call ...>'

--- a/contrib/docker/gh-build.sh
+++ b/contrib/docker/gh-build.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Build and push Docker images for GitHub builds.
 
 IMAGE_NAME=${IMAGE_NAME:-theminerzcoin}
 TAG=${GIT_CURRENT_BRANCH:-latest}

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
+set -euo pipefail
+# Install libdb4.8 (Berkeley DB).
 # Copyright (c) 2017-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-# Install libdb4.8 (Berkeley DB).
-
 export LC_ALL=C
-set -e
 
 if [ -z "${1}" ]; then
   echo "Usage: $0 <base-dir> [<extra-bdb-configure-flag> ...]"

--- a/contrib/macdeploy/detached-sig-apply.sh
+++ b/contrib/macdeploy/detached-sig-apply.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -euo pipefail
+# Apply detached signature to an unsigned macOS application.
 # Copyright (c) 2014-2021 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
+set -euo pipefail
+# Create a detached signature for a macOS application bundle.
 # Copyright (c) 2014-2021 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 export LC_ALL=C
-set -e
 
 ROOTDIR=dist
 BUNDLE="${ROOTDIR}/TheMinerzCoin-Qt.app"

--- a/contrib/qos/tc.sh
+++ b/contrib/qos/tc.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+# Apply traffic shaping rules for TheMinerzCoin.
 #
 # Copyright (c) 2017-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying

--- a/contrib/verify-commits/gpg.sh
+++ b/contrib/verify-commits/gpg.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -euo pipefail
+# Verify commit signatures using gpg.
 # Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/contrib/verify-commits/pre-push-hook.sh
+++ b/contrib/verify-commits/pre-push-hook.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+# Git pre-push hook to ensure commits are signed.
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/contrib/verifybinaries/verify.sh
+++ b/contrib/verifybinaries/verify.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+# Verify released binaries against signed hashes.
 # Copyright (c) 2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/contrib/windeploy/detached-sig-create.sh
+++ b/contrib/windeploy/detached-sig-create.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -euo pipefail
+# Create a detached Windows signature using osslsigncode.
 # Copyright (c) 2014-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -euo pipefail
+# Generate build information from git for embedding into binaries.
 # Copyright (c) 2012-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.


### PR DESCRIPTION
## Summary
- enable `set -euo pipefail` across contrib and share scripts
- add short description headers to each script for consistency

## Testing
- `bash -n $(find contrib share -name '*.sh')`

