### PR TITLE
Add ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,16 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v18.1.0
+    rev: 6b9072cd80691b1b48d80046d884409fb1d962d1  # frozen: v20.1.7
     hooks:
       - id: clang-format
         files: '\.(cpp|h)$'
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 0b19ef1fd6ad680ed7752d6daba883ce1265a6de  # frozen: v0.12.2
+    hooks:
+      - id: ruff
+        args: ["check"]
+        files: '\.(py)$'
 
   - repo: local
     hooks:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,8 +40,9 @@ pip install pre-commit
 pre-commit install
 ```
 
-Running the hooks will apply `clang-format` to C++ sources, `rustfmt` to Rust
-files, and execute `cargo fmt --check` for the crate in `rust/`.
+Running the hooks will apply `clang-format` to C++ sources, `ruff` to Python
+files, `rustfmt` to Rust files, and execute `cargo fmt --check` for the crate in
+`rust/`.
 
 Compilation Database
 --------------------


### PR DESCRIPTION
## Summary
- add `ruff` to the pre-commit configuration
- freeze hook versions
- document ruff in contributing guide

## Testing
- `pre-commit run --files docs/CONTRIBUTING.md`


