### PR TITLE
Fix build scripts to use bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Then point CMake at the generated prefix when configuring:
 ./generate_build.sh -DCMAKE_PREFIX_PATH=$(pwd)/depends/x86_64-linux-gnu
 ```
 
+Note: These helper scripts rely on Bash. If `/bin/sh` is not Bash on your
+system, invoke them explicitly with `bash ./generate_build.sh`.
+
 See [depends/README.md](depends/README.md) for more advanced options and cross-compilation details.
 
 To build everything in one go using Conan and CMake:

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Simple wrapper to invoke the CMake build from project root.
 set -euo pipefail
+
+if [ ! -d build ]; then
+    echo "Generating build directory..."
+    ./generate_build.sh
+fi
 
 cmake --build build "$@"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,10 @@
-#Changelog
+# Changelog
+
+## Unreleased
+### Deutsch
+- Shebang der Buildskripte auf Bash umgestellt, damit `pipefail` funktioniert
+### English
+- Switched build script shebangs to Bash for proper `pipefail` support
 
 ## v3.0.0 (2025-07-03)
 - Taproot and Schnorr activated

--- a/generate_build.sh
+++ b/generate_build.sh
@@ -1,5 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Generate a CMake build directory.
 set -euo pipefail
 
-cmake -S . -B build -DCRC32C_USE_GLOG=OFF "$@"
+if [ -d build ]; then
+    echo "Using existing build directory" >&2
+else
+    cmake -S . -B build -DCRC32C_USE_GLOG=OFF "$@"
+fi

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Install build artifacts from the CMake build directory.
 set -euo pipefail
+
+if [ ! -d build ]; then
+    echo "Build directory missing; run ./generate_build.sh first" >&2
+    exit 1
+fi
 
 cmake --install build "$@"


### PR DESCRIPTION
## Summary
- use bash shebang in helper scripts
- generate build directory when missing
- mention bash requirement in README
- note change in bilingual CHANGELOG entry

## Testing
- `pre-commit run --files build.sh generate_build.sh install.sh README.md docs/CHANGELOG.md`
- `python -m pytest -q`
- `cargo test --manifest-path rust/Cargo.toml`

