### PR TITLE
Fix Python tooling scripts

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 
+
 class TheMinerzCoinConan(ConanFile):
     name = "TheMinerzCoin"
     version = "0.1"

--- a/contrib/devtools/update-translations.py
+++ b/contrib/devtools/update-translations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # Copyright (c) 2014 Wladimir J. van der Laan
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 
+
 def setup():
     global args, workdir
     programs = ['ruby', 'git', 'make', 'wget', 'curl']

--- a/share/qt/extract_strings_qt.py
+++ b/share/qt/extract_strings_qt.py
@@ -6,10 +6,10 @@
 Extract _("...") strings for translation and convert to Qt stringdefs so that
 they can be picked up by Qt linguist.
 '''
-from subprocess import Popen, PIPE
 import operator
 import os
 import sys
+from subprocess import PIPE, Popen
 
 OUT_CPP="qt/bitcoinstrings.cpp"
 EMPTY=['""']
@@ -58,13 +58,13 @@ if not XGETTEXT:
     print('Cannot extract strings: xgettext utility is not installed or not configured.',file=sys.stderr)
     print('Please install package "gettext" and re-run \'./configure\'.',file=sys.stderr)
     sys.exit(1)
-child = Popen([XGETTEXT,'--output=-','--from-code=utf-8','-n','--keyword=_'] + files, stdout=PIPE)
-(out, err) = child.communicate()
+child = Popen([XGETTEXT, '--output=-', '--from-code=utf-8', '-n', '--keyword=_'] + files, stdout=PIPE)
+out, _ = child.communicate()
 
 messages = parse_po(out.decode('utf-8'))
 
-f = open(OUT_CPP, 'w', encoding="utf8")
-f.write("""
+with open(OUT_CPP, 'w', encoding="utf8") as f:
+    f.write("""
 
 #include <QtGlobal>
 
@@ -75,11 +75,10 @@ f.write("""
 #define UNUSED
 #endif
 """)
-f.write('static const char UNUSED *bitcoin_strings[] = {\n')
-f.write('QT_TRANSLATE_NOOP("bitcoin-core", "%s"),\n' % (os.getenv('COPYRIGHT_HOLDERS'),))
-messages.sort(key=operator.itemgetter(0))
-for (msgid, msgstr) in messages:
-    if msgid != EMPTY:
-        f.write('QT_TRANSLATE_NOOP("bitcoin-core", %s),\n' % ('\n'.join(msgid)))
-f.write('};\n')
-f.close()
+    f.write('static const char UNUSED *bitcoin_strings[] = {\n')
+    f.write('QT_TRANSLATE_NOOP("bitcoin-core", "%s"),\n' % (os.getenv('COPYRIGHT_HOLDERS'),))
+    messages.sort(key=operator.itemgetter(0))
+    for (msgid, msgstr) in messages:
+        if msgid != EMPTY:
+            f.write('QT_TRANSLATE_NOOP("bitcoin-core", %s),\n' % ('\n'.join(msgid)))
+    f.write('};\n')

--- a/share/rpcauth/rpcauth.py
+++ b/share/rpcauth/rpcauth.py
@@ -3,13 +3,13 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import hmac
 from argparse import ArgumentParser
 from base64 import urlsafe_b64encode
 from binascii import hexlify
 from getpass import getpass
 from os import urandom
 
-import hmac
 
 def generate_salt(size):
     """Create size byte hex salt"""

--- a/src/test/bitcoin-util-test.py
+++ b/src/test/bitcoin-util-test.py
@@ -1,9 +1,11 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # Copyright 2014 BitPay, Inc.
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-from __future__ import division,print_function,unicode_literals
+from __future__ import division, print_function, unicode_literals
+
 import os
+
 import bctest
 import buildenv
 

--- a/src/test/buildenv.py
+++ b/src/test/buildenv.py
@@ -1,2 +1,2 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 exeext=""

--- a/src/test/buildenv.py.in
+++ b/src/test/buildenv.py.in
@@ -1,2 +1,2 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 exeext="@EXEEXT@"


### PR DESCRIPTION
## Summary
- run ruff on several python utilities
- modernize shebangs to `python3`
- improve extract_strings_qt script

## Testing
- `ruff check share/qt/extract_strings_qt.py share/rpcauth/rpcauth.py contrib/gitian-build.py conanfile.py contrib/devtools/update-translations.py src/test/bitcoin-util-test.py src/test/buildenv.py src/test/buildenv.py.in`
- `pre-commit run --files share/qt/extract_strings_qt.py share/rpcauth/rpcauth.py contrib/gitian-build.py conanfile.py contrib/devtools/update-translations.py src/test/bitcoin-util-test.py src/test/buildenv.py src/test/buildenv.py.in` *(fails: E902 No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687b3124efdc832c981ec325c777cc8f